### PR TITLE
New installer option: rootsize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The format of the file and the current defaults:
     rootpw=raspbian
     cdebootstrap_cmdline=
     bootsize=+50M # /boot partition size as given to fdisk
+    rootsize=     # / partition size, leave empty to use all free space
     timeserver=time.nist.gov
     ip_addr=dhcp
     ip_netmask=0.0.0.0

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -9,6 +9,7 @@ hostname=pi
 rootpw=raspbian
 cdebootstrap_cmdline=
 bootsize=+50M
+rootsize=
 timeserver=time.nist.gov
 ip_addr=dhcp
 ip_netmask=0.0.0.0
@@ -245,6 +246,7 @@ echo "  hostname = $hostname"
 echo "  rootpw = $rootpw"
 echo "  cdebootstrap_cmdline = $cdebootstrap_cmdline"
 echo "  bootsize = $bootsize"
+echo "  rootsize = $rootsize"
 echo "  timeserver = $timeserver"
 echo "  cmdline = $cmdline"
 echo "  usbroot = $usbroot"
@@ -299,7 +301,7 @@ n
 p
 2
 
-
+$rootsize
 w
 EOF
     echo "OK"
@@ -325,7 +327,7 @@ n
 p
 1
 
-
+$rootsize
 w
 EOF
     echo "OK"


### PR DESCRIPTION
Hi!
For large SD cards like mine 64GB it can save hours not to use whole free space for root partition at installation time. When system is installed and running one can use remaining free space for additional partitioning.

Cheers,
Piotrek
