### PR TITLE
Disable fsck for f2fs

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -381,7 +381,11 @@ echo -n root:$rootpw | chroot /rootfs /usr/sbin/chpasswd || fail
 
 # default mounts
 echo "$bootpartition /boot vfat defaults 0 2" > /rootfs/etc/fstab || fail
-echo "$rootpartition / $rootfstype $rootfs_mount_options 0 1" >> /rootfs/etc/fstab || fail
+if [ "$rootfstype" = "f2fs" ]; then
+	echo "$rootpartition / $rootfstype $rootfs_mount_options 0 0" >> /rootfs/etc/fstab || fail
+else
+	echo "$rootpartition / $rootfstype $rootfs_mount_options 0 1" >> /rootfs/etc/fstab || fail
+fi
 
 # use ram tmpfs by default
 echo "RAMTMP=yes" >> /rootfs/etc/default/tmpfs 


### PR DESCRIPTION
Because fsck.f2fs doesn’t exist, fsck fail’s.
