### PR TITLE
Enabled serial console output during the install process.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,7 +98,7 @@ cp installer.cpio bootfs/
 
 echo "kernel=kernel_install.img" > bootfs/config.txt
 echo "initramfs installer.cpio" >> bootfs/config.txt
-echo "consoleblank=0" > bootfs/cmdline.txt
+echo "consoleblank=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > bootfs/cmdline.txt
 
 ZIPFILE=raspbian-ua-netinst-`date +%Y%m%d`-git`git rev-parse --short @{0}`.zip
 rm -f $ZIPFILE


### PR DESCRIPTION
Allows to monitor the install process through the serial port, in case the user has no display to connect the pi.

![screenshot - 30-05-2014 - 15 15 15](https://cloud.githubusercontent.com/assets/911097/3131477/e7bc55a2-e804-11e3-9a5f-293e589ff352.png)
