### PR TITLE
Fix check for losetup version

### DIFF
--- a/buildroot.sh
+++ b/buildroot.sh
@@ -28,7 +28,7 @@ else
   losetup_lt_2_22=false
 fi
 
-if [ $losetup_lt_2_22 ] ; then
+if [ "$losetup_lt_2_22" = "true" ] ; then
 
 kpartx -as $IMG || exit
 mkfs.vfat /dev/mapper/loop0p1 || exit


### PR DESCRIPTION
Before, the test always evaluated to true and kpartx was used. Now, the test actually depends on the value of `losetup_lt_2_22`.
