### PR TITLE
Force authentication for cdebootstrap-static

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,16 @@ mkdir -p rootfs/usr/bin/
 cp -r tmp/usr/share/cdebootstrap-static rootfs/usr/share/
 cp tmp/usr/bin/cdebootstrap-static rootfs/usr/bin/
 
+# install raspbian-archive-keyring (for cdebootstrap)
+mkdir -p rootfs/usr/share/keyrings/
+cp tmp/usr/share/keyrings/raspbian-archive-keyring.gpg rootfs/usr/share/keyrings/
+
+# install gpgv (for cdebootstrap)
+cp tmp/usr/bin/gpgv rootfs/usr/bin/
+
+# install libbz2-1.0 (for gpgv)
+cp tmp/lib/*/libbz2.so.1.0.* rootfs/lib/libbz2.so.1.0
+
 # libs for mkfs
 cp tmp/lib/*/libcom_err.so.2.1 rootfs/lib/libcom_err.so.2
 cp tmp/lib/*/libe2p.so.2.3 rootfs/lib/libe2p.so.2

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -397,7 +397,7 @@ if [ "$kernel_module" = true ] ; then
 fi
 
 echo "Starting install process..."
-cdebootstrap-static --arch=armhf --allow-unauthenticated $cdebootstrap_cmdline $release /rootfs $mirror || fail
+cdebootstrap-static --arch=armhf $cdebootstrap_cmdline $release /rootfs $mirror --keyring=/usr/share/keyrings/raspbian-archive-keyring.gpg || fail
 
 # allow root login
 echo "Configuring installed system:"

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ KERNEL_VERSION=3.10-3-rpi
 
 mirror=http://archive.raspbian.org/raspbian/
 release=jessie
-packages="busybox-static libc6 cdebootstrap-static e2fslibs e2fsprogs libcomerr2 libblkid1 libuuid1 libgcc1 dosfstools linux-image-${KERNEL_VERSION} raspberrypi-bootloader-nokernel f2fs-tools btrfs-tools zlib1g liblzo2-2"
+packages="busybox-static libc6 cdebootstrap-static raspbian-archive-keyring e2fslibs e2fsprogs gpgv libbz2-1.0 libcomerr2 libblkid1 libuuid1 libgcc1 dosfstools linux-image-${KERNEL_VERSION} raspberrypi-bootloader-nokernel f2fs-tools btrfs-tools zlib1g liblzo2-2"
 packages_found=
 packages_debs=
 


### PR DESCRIPTION
Before, during initial bootstrapping, cdebootstrap-static ignored "the unavailability of Release.gpg, missing keyrings, broken signatures, and missing gpgv executable". This commit adds the necessary dependencies to be able to perform the verifications. Following this commit, the signatures/checksums on the Release file and all packages are properly checked.

Note that before this change, downloads of all of the packages during installation were performed over an unencrypted http connection with no verification, so they were subject to man-in-the-middle attacks.
