### PR TITLE
add tee for create a logfile for post-install.txt

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -554,7 +554,7 @@ echo "OK"
 if [ -e /bootfs/post-install.txt ]; then
     echo "Running post-install.txt..."
     sanitize_inputfile /bootfs/post-install.txt
-    source /bootfs/post-install.txt
+    source /bootfs/post-install.txt 2>&1 | tee -a post-install.log
 fi
 
 # save current time if fake-hwclock


### PR DESCRIPTION
post-install.txt could be used for post installation, and so, it could be good to have a logfile which is a copy of stdout and stderr, for later debugging purpose.
