### PR TITLE
Include customs installation files in zip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,14 @@ echo "kernel=kernel_install.img" > bootfs/config.txt
 echo "initramfs installer.cpio" >> bootfs/config.txt
 echo "consoleblank=0" > bootfs/cmdline.txt
 
+if [ -f installer-config.txt ]; then
+    cp installer-config.txt bootfs/installer-config.txt
+fi
+
+if [ -f post-install.txt ]; then
+    cp post-install.txt bootfs/post-install.txt
+fi
+
 ZIPFILE=raspbian-ua-netinst-`date +%Y%m%d`-git`git rev-parse --short @{0}`.zip
 rm -f $ZIPFILE
 


### PR DESCRIPTION
If installer-config.txt and post-install.txt are present in the directory, these files are copied in the zip file.
When the zip file is uncompressed on sd, the customs installation files are already available.
