### PR TITLE
Changed the console blank timeout

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -66,6 +66,10 @@ sanitize_inputfile()
     fi
 }
 
+# set screen blank period to an hour
+# hopefully the install should be done by then
+echo -en '\033[9;60]'
+
 mkdir -p /proc
 mkdir -p /sys
 mkdir -p /boot


### PR DESCRIPTION
The screen blanks after a predefined timeout (during installation).
This change sets that timeout to 60 minutes, buy which time the
installation should hopefully be finished.
