### PR TITLE
Build .img.bz2 as well and make .img.xz optional

### DIFF
--- a/buildroot.sh
+++ b/buildroot.sh
@@ -50,4 +50,10 @@ losetup -D || true
 
 fi
 
-xz -9 $IMG
+{
+  cat $IMG | xz -9 > $IMG.xz
+} || {
+  echo "WARNING: Could not create '$IMG.xz' variant." >&2
+}
+# As a courtesy to OS X users :)
+cat $IMG | bzip2 -9 > $IMG.bz2

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm -rf bootfs rootfs firmware packages tmp installer.cpio *.zip *.xz *.img
+rm -rf bootfs rootfs firmware packages tmp installer.cpio *.zip *.xz *.bz2 *.img


### PR DESCRIPTION
The build runs fine on Raspberry Pi, but `xz` needs more memory than Pi provides.
