### PR TITLE
build.sh: Simplify

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,9 +81,13 @@ rm -rf tmp
 mkdir tmp
 
 # extract debs
-for i in packages/*.deb; do
-    cd tmp && ar x ../$i && tar -xf data.tar.*; rm data.tar.*; cd ..
+cd tmp
+for i in ../packages/*.deb; do
+    ar x $i
+    tar -xf data.tar.*
+    rm data.tar.*
 done
+cd -
 
 # initialize bootfs
 rm -rf bootfs


### PR DESCRIPTION
If either `tar` or `rm` break (which is allowed by the old version), use this idiom on them:

```
if ! <possible failing command> ; then
    echo "failure ignored"
fi
```

See http://robertmuth.blogspot.ch/2012/08/better-bash-scripting-in-15-minutes.html
