### PR TITLE
Replace rdate with BusyBox ntpd applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The format of the file and the current defaults:
     rootfs_mount_options='errors=remount-ro,noatime'
 
 All of the configuration options should be clear. You can override any of these in your _installer-config.txt_.  
-The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
+The time server is only used during installation.
 **Note:** You only need to provide the options which you want to **override** in your _installer-config.txt_ file.  
 All non-provided options will use the defaults as mentioned above.
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -251,7 +251,7 @@ if [ "$date_set" = "false" ] ; then
     timeservers="$timeservers nist1-ny2.ustiming.org wwv.nist.gov"
     for ts in $timeservers
     do
-        rdate $ts &>/dev/null
+        ntpd -q -p $ts &>/dev/null
         if [ $? -eq 0 ]; then
             echo -n "Time set using timeserver '$ts' to... "
             date
@@ -264,7 +264,6 @@ if [ "$date_set" = "false" ] ; then
 fi
 if [ "$date_set" = "false" ] ; then
     echo "FAILED to set the date, so things are likely to fail now ..."
-    echo "Make sure that rdate port 37 is not blocked by your firewall."
 fi
 
 # Record the time now that the time is set to a correct value


### PR DESCRIPTION
It isn't documented well but ntpd exists within BusyBox.

http://www.busybox.net/tinyutils.html - "BusyBox starting from 1.16.x also acquired ntpd applet."
