### PR TITLE
Do not create a new partition table if the drive is already partitioned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /raspbian-ua-netinst-*.img
 /raspbian-ua-netinst-*.img.xz
 /raspbian-ua-netinst-*.img.bz2
+installer-config.txt
+
+# Ignore backup files created by gedit
+*~

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -335,7 +335,10 @@ if [ "$usbroot" != "" ]; then
     echo "OK"
 fi
 
+manually_specified_root_partition=true
 if [ "$rootpartition" = "" ]; then
+    manually_specified_root_partition=false
+
     if [ "$rootdev" = "/dev/sda" ]; then
         rootpartition=/dev/sda1
     else
@@ -418,9 +421,13 @@ w
 EOF
     echo "OK"
 
-    echo -n "Applying new partition table for $rootdev... "
-    dd if=/dev/zero of=$rootdev bs=512 count=1 &>/dev/null
-    fdisk $rootdev &>/dev/null <<EOF
+    # If the user manually specified a partition, we can suppose the drive is
+    # already partitioned and therefore we don't need to create a new
+    # partition table
+    if [ "$manually_specified_root_partition" = "false" ]; then
+        echo -n "Applying new partition table for $rootdev... "
+        dd if=/dev/zero of=$rootdev bs=512 count=1 &>/dev/null
+        fdisk $rootdev &>/dev/null <<EOF
 n
 p
 1
@@ -428,7 +435,8 @@ p
 $rootsize
 w
 EOF
-    echo "OK"
+        echo "OK"
+    fi
 
 fi
 


### PR DESCRIPTION
Basically I manually specified a partition, hoping that the installer won't touch the other partitions which had valuable data, just to discover later that the MBR was wiped :v: 

This PR modifies the installation script so that if the partition is manually specified the drive isn't repartitioned, because we already have a partition ready to be used.

This modification also raises another question: why repartition the SD if the root partition is in an external drive? Can't we just format the boot partition and leave the MBR and the rest of the partitions untoched? Either way I consider this out of the scope of this PR.