### PR TITLE
Added configuration for installing over wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,13 @@ The format of the file and the current defaults:
     timezone=Etc/UTC # set to desired timezone (e.g. Europe/Ljubljana)
     locales=  # a space delimited list of locales that will be generated during install (e.g. "en_US.UTF-8 nl_NL sl_SI.UTF-8")
     system_default_locale= # the default system locale to set (using the LANG environment variable)
+    ifname=eth0
     ip_addr=dhcp
     ip_netmask=0.0.0.0
     ip_broadcast=0.0.0.0
     ip_gateway=0.0.0.0
     ip_nameservers=
+    wlandriver=
     online_config= # URL to extra config that will be executed after installer-config.txt
     usbroot= # set to 1 to install to first USB disk
     cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The format of the file and the current defaults:
     ip_broadcast=0.0.0.0
     ip_gateway=0.0.0.0
     ip_nameservers=
-    wlandriver=
+    drivers_to_load=
     online_config= # URL to extra config that will be executed after installer-config.txt
     usbroot= # set to 1 to install to first USB disk
     cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"

--- a/build.sh
+++ b/build.sh
@@ -106,6 +106,7 @@ mkdir -p rootfs/sbin/
 mkdir -p rootfs/usr/bin/
 mkdir -p rootfs/usr/share/
 mkdir -p rootfs/usr/share/keyrings/
+mkdir -p rootfs/drivers/wireless
 
 cp -a tmp/lib/modules/${KERNEL_VERSION}/modules.{builtin,order} rootfs/lib/modules/${KERNEL_VERSION}
 
@@ -200,6 +201,7 @@ cp tmp/lib/*/libcom_err.so.2.1 rootfs/lib/libcom_err.so.2
 
 # libgcc1 components
 cp tmp/lib/*/libgcc_s.so.1 rootfs/lib/
+cp tmp/lib/*/librt.so.1 rootfs/lib/
 
 # liblzo2-2 components
 cp tmp/lib/*/liblzo2.so.2 rootfs/lib/liblzo2.so.2
@@ -209,6 +211,30 @@ cp tmp/lib/*/libuuid.so.1.3.0 rootfs/lib/libuuid.so.1
 
 # zlib1g components
 cp tmp/lib/*/libz.so.1  rootfs/lib/libz.so.1
+
+# wpa_supplicant components
+cp tmp/sbin/wpa_supplicant rootfs/sbin/wpa_supplicant
+cp -r tmp/etc/wpa_supplicant rootfs/etc/wpa_supplicant
+
+# firmware realtek
+cp tmp/lib/modules/*/kernel/drivers/net/wireless/rtl8192cu/8192cu.ko rootfs/drivers/wireless/8192cu.ko
+
+# libssl components
+cp tmp/usr/lib/*/libssl.so.1.0.0 rootfs/lib/libssl.so.1.0.0
+cp tmp/usr/lib/*/libcrypto.so.1.0.0 rootfs/lib/libcrypto.so.1.0.0
+
+# libdbus components
+cp tmp/lib/*/libdbus-1.so.3 rootfs/lib/libdbus-1.so.3
+cp tmp/lib/*/libdl.so.2 rootfs/lib/libdl.so.2
+
+# libnl components
+cp tmp/lib/*/libnl-3.so.200 rootfs/lib/libnl-3.so.200
+
+# libnl-genl components
+cp tmp/lib/*/libnl-genl-3.so.200 rootfs/lib/libnl-genl-3.so.200
+
+# libpcsclite components
+cp tmp/usr/lib/*/libpcsclite.so.1 rootfs/lib/libpcsclite.so.1
 
 cd rootfs && find . | cpio -H newc -ov > ../installer.cpio
 cd ..

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ rm -rf bootfs
 mkdir -p bootfs
 
 # raspberrypi-bootloader-nokernel components and kernel
-cp tmp/boot/* bootfs/
+cp -r tmp/boot/* bootfs/
 rm bootfs/System*
 rm bootfs/config-*
 mv bootfs/vmlinuz* bootfs/kernel_install.img
@@ -106,7 +106,6 @@ mkdir -p rootfs/sbin/
 mkdir -p rootfs/usr/bin/
 mkdir -p rootfs/usr/share/
 mkdir -p rootfs/usr/share/keyrings/
-mkdir -p rootfs/drivers/wireless
 
 cp -a tmp/lib/modules/${KERNEL_VERSION}/modules.{builtin,order} rootfs/lib/modules/${KERNEL_VERSION}
 
@@ -182,6 +181,10 @@ cp packages/raspberrypi.gpg.key rootfs/usr/share/keyrings/
 # raspbian-archive-keyring components
 cp tmp/usr/share/keyrings/raspbian-archive-keyring.gpg rootfs/usr/share/keyrings/
 
+# wpa_supplicant components
+cp tmp/sbin/wpa_supplicant rootfs/sbin/wpa_supplicant
+cp -r tmp/etc/wpa_supplicant rootfs/etc/wpa_supplicant
+
 # libblkid1 components
 cp tmp/lib/*/libblkid.so.1.1.0 rootfs/lib/libblkid.so.1
 
@@ -199,33 +202,16 @@ cp tmp/lib/*/libpthread-*.so rootfs/lib/libpthread.so.0
 # libcomerr2 components
 cp tmp/lib/*/libcom_err.so.2.1 rootfs/lib/libcom_err.so.2
 
+# libdbus components
+cp tmp/lib/*/libdbus-1.so.3 rootfs/lib/libdbus-1.so.3
+cp tmp/lib/*/libdl.so.2 rootfs/lib/libdl.so.2
+
 # libgcc1 components
 cp tmp/lib/*/libgcc_s.so.1 rootfs/lib/
 cp tmp/lib/*/librt.so.1 rootfs/lib/
 
 # liblzo2-2 components
 cp tmp/lib/*/liblzo2.so.2 rootfs/lib/liblzo2.so.2
-
-# libuuid1 components
-cp tmp/lib/*/libuuid.so.1.3.0 rootfs/lib/libuuid.so.1
-
-# zlib1g components
-cp tmp/lib/*/libz.so.1  rootfs/lib/libz.so.1
-
-# wpa_supplicant components
-cp tmp/sbin/wpa_supplicant rootfs/sbin/wpa_supplicant
-cp -r tmp/etc/wpa_supplicant rootfs/etc/wpa_supplicant
-
-# firmware realtek
-cp tmp/lib/modules/*/kernel/drivers/net/wireless/rtl8192cu/8192cu.ko rootfs/drivers/wireless/8192cu.ko
-
-# libssl components
-cp tmp/usr/lib/*/libssl.so.1.0.0 rootfs/lib/libssl.so.1.0.0
-cp tmp/usr/lib/*/libcrypto.so.1.0.0 rootfs/lib/libcrypto.so.1.0.0
-
-# libdbus components
-cp tmp/lib/*/libdbus-1.so.3 rootfs/lib/libdbus-1.so.3
-cp tmp/lib/*/libdl.so.2 rootfs/lib/libdl.so.2
 
 # libnl components
 cp tmp/lib/*/libnl-3.so.200 rootfs/lib/libnl-3.so.200
@@ -235,6 +221,21 @@ cp tmp/lib/*/libnl-genl-3.so.200 rootfs/lib/libnl-genl-3.so.200
 
 # libpcsclite components
 cp tmp/usr/lib/*/libpcsclite.so.1 rootfs/lib/libpcsclite.so.1
+
+# libssl components
+cp tmp/usr/lib/*/libssl.so.1.0.0 rootfs/lib/libssl.so.1.0.0
+cp tmp/usr/lib/*/libcrypto.so.1.0.0 rootfs/lib/libcrypto.so.1.0.0
+
+# libuuid1 components
+cp tmp/lib/*/libuuid.so.1.3.0 rootfs/lib/libuuid.so.1
+
+# zlib1g components
+cp tmp/lib/*/libz.so.1  rootfs/lib/libz.so.1
+
+# drivers
+mkdir -p rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net
+cp -r tmp/lib/modules/*/kernel/drivers/net/wireless rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net/
+
 
 cd rootfs && find . | cpio -H newc -ov > ../installer.cpio
 cd ..

--- a/config/apt/sources.list
+++ b/config/apt/sources.list
@@ -1,1 +1,1 @@
-deb http://mirrordirector.raspbian.org/raspbian __RELEASE__ main firmware
+deb http://mirrordirector.raspbian.org/raspbian __RELEASE__ main firmware non-free

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -29,7 +29,7 @@ ip_netmask=0.0.0.0
 ip_broadcast=0.0.0.0
 ip_gateway=0.0.0.0
 ip_nameservers=
-wlandriver=
+drivers_to_load=
 online_config=
 usbroot=
 cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
@@ -208,8 +208,10 @@ echo "Waiting for $ifname... "
 
 if [ "$ifname" != "eth0" ]; then
     # if eth0 is not the chosen eth interface it is a wireless interface and a driver must be loaded
-    echo -n "Loding driver $wlandriver... "
-    insmod /drivers/wireless/$wlandriver || fail
+    echo -n "Loading drivers $drivers_to_load... "
+    # depmod needs to update modules.dep
+    depmod -a
+    modprobe /lib/modules/$(uname -r)/kernel/drivers/$drivers_to_load || fail
     [ $? -eq 0 ] && echo "OK"
     # Also, replace eth0 as udhcpc dns interface
     sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
@@ -235,8 +237,8 @@ done
 if [ "$ifname" != "eth0" ]; then
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
     echo -n "Running wpa_supplicant... "
-    wpa_supplicant -B -Dwext -c/bootfs/config/wpa_supplicant.conf -iwlan0 >& /dev/null || fail
-    [ $? -eq 0 ] && echo "OK"
+    wpa_supplicant -B -Dnl80211,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail
+    echo "OK"
 fi
 
 if [ "$ip_addr" = "dhcp" ]; then
@@ -817,7 +819,7 @@ fi
 if [ "$ifname" != "eth0" ]; then
     # Install wireless dependencies
     echo -n "Installing wpasupplicant package... "
-    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant firmware-realtek >& /dev/null
+    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant >& /dev/null
     if [ $? -eq 0 ]; then
         echo "OK"
     else

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -23,11 +23,13 @@ timeserver=time.nist.gov
 timezone=Etc/UTC
 locales=
 system_default_locale=
+ifname=eth0
 ip_addr=dhcp
 ip_netmask=0.0.0.0
 ip_broadcast=0.0.0.0
 ip_gateway=0.0.0.0
 ip_nameservers=
+wlandriver=
 online_config=
 usbroot=
 cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
@@ -163,6 +165,10 @@ if [ -e /bootfs/installer-config.txt ]; then
     echo "================================================="
 fi
 
+if [ -e /bootfs/config/wpa_supplicant.conf ]; then
+    sanitize_inputfile /bootfs/config/wpa_supplicant.conf
+fi
+
 case "$rootfstype" in
   "btrfs")
     kernel_module=true
@@ -198,11 +204,20 @@ fi
 echo "  online_config = $online_config"
 echo
 
-echo -n "Waiting for eth0... "
+echo "Waiting for $ifname... "
+
+if [ "$ifname" != "eth0" ]; then
+    # if eth0 is not the chosen eth interface it is a wireless interface and a driver must be loaded
+    echo -n "Loding driver $wlandriver... "
+    insmod /drivers/wireless/$wlandriver || fail
+    [ $? -eq 0 ] && echo "OK"
+    # Also, replace eth0 as udhcpc dns interface
+    sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
+fi
 
 for i in `seq 1 10`; do
 
-    ifconfig eth0 &>/dev/null
+    ifconfig $ifname &>/dev/null
     if [ $? -eq 0 ]; then
         break
     fi
@@ -217,19 +232,26 @@ for i in `seq 1 10`; do
     echo -n "$i.. "
 done
 
-if [ "$ip_addr" = "dhcp" ]; then
-    echo -n "Configuring eth0 with DHCP... "
+if [ "$ifname" != "eth0" ]; then
+    # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
+    echo -n "Running wpa_supplicant... "
+    wpa_supplicant -B -Dwext -c/bootfs/config/wpa_supplicant.conf -iwlan0 >& /dev/null || fail
+    [ $? -eq 0 ] && echo "OK"
+fi
 
-    udhcpc -i eth0 &>/dev/null
+if [ "$ip_addr" = "dhcp" ]; then
+    echo -n "Configuring $ifname with DHCP... "
+
+    udhcpc -i $ifname &>/dev/null
     if [ $? -eq 0 ]; then
-        ifconfig eth0 | fgrep addr: | awk '{print $2}' | cut -d: -f2
+        ifconfig $ifname | fgrep addr: | awk '{print $2}' | cut -d: -f2
     else
         echo "FAILED"
         fail
     fi
 else
-    echo -n "Configuring eth0 with static ip $ip_addr... "
-    ifconfig eth0 up inet $ip_addr netmask $ip_netmask broadcast $ip_broadcast || fail
+    echo -n "Configuring $ifname with static ip $ip_addr... "
+    ifconfig $ifname up inet $ip_addr netmask $ip_netmask broadcast $ip_broadcast || fail
     route add default gw $ip_gateway || fail
     echo -n > /etc/resolv.conf
     for i in $ip_nameservers; do
@@ -601,17 +623,20 @@ echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces || fail
 echo "" >>  /rootfs/etc/network/interfaces || fail
 
 # eth0 config
-echo "auto eth0" >> /rootfs/etc/network/interfaces || fail
+echo "auto $ifname" >> /rootfs/etc/network/interfaces || fail
 if [ "$ip_addr" = "dhcp" ]; then
-    echo "iface eth0 inet dhcp" >> /rootfs/etc/network/interfaces || fail
+    echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces || fail
 else
-    echo "iface eth0 inet static" >> /rootfs/etc/network/interfaces || fail
+    echo "iface $ifname inet static" >> /rootfs/etc/network/interfaces || fail
     echo "    address $ip_addr" >> /rootfs/etc/network/interfaces || fail
     echo "    netmask $ip_netmask" >> /rootfs/etc/network/interfaces || fail
     echo "    broadcast $ip_broadcast" >> /rootfs/etc/network/interfaces || fail
     echo "    gateway $ip_gateway" >> /rootfs/etc/network/interfaces || fail
 
     cp /etc/resolv.conf /rootfs/etc/ || fail
+fi
+if [ "$ifname" != "eth0" ]; then
+    echo "wpa-conf /boot/config/wpa_supplicant.conf" >> /rootfs/etc/network/interfaces || fail
 fi
 echo "OK"
 
@@ -786,6 +811,18 @@ if [ $? -eq 0 ]; then
     echo "OK"
 else
     echo "FAILED !"
+fi
+
+# if eth0 was not used during initial boot, a wireless interfaces was used
+if [ "$ifname" != "eth0" ]; then
+    # Install wireless dependencies
+    echo -n "Installing wpasupplicant package... "
+    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant firmware-realtek >& /dev/null
+    if [ $? -eq 0 ]; then
+        echo "OK"
+    else
+        echo "FAILED !"
+    fi
 fi
 
 # add reasonable default modules, works only after kernel is properly installed

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -204,18 +204,24 @@ fi
 echo "  online_config = $online_config"
 echo
 
-echo "Waiting for $ifname... "
-
-if [ "$ifname" != "eth0" ]; then
-    # if eth0 is not the chosen eth interface it is a wireless interface and a driver must be loaded
-    echo -n "Loading drivers $drivers_to_load... "
-    # depmod needs to update modules.dep
-    depmod -a
-    modprobe /lib/modules/$(uname -r)/kernel/drivers/$drivers_to_load || fail
-    [ $? -eq 0 ] && echo "OK"
-    # Also, replace eth0 as udhcpc dns interface
-    sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
+# depmod needs to update modules.dep before using modprobe
+depmod -a
+if [ "$drivers_to_load" != "" ] ; then
+   echo "Loading additional drivers."
+   for driver in $drivers_to_load
+   do
+      echo -n " Loading driver '$driver' ... "
+      modprobe $driver || fail
+      if [ $? -eq 0 ] ; then
+         echo "OK"
+      else
+         echo "FAILED !"
+      fi
+   done
+   echo "Finished loading additional drivers"
 fi
+
+echo "Waiting for $ifname... "
 
 for i in `seq 1 10`; do
 
@@ -235,6 +241,8 @@ for i in `seq 1 10`; do
 done
 
 if [ "$ifname" != "eth0" ]; then
+    # Replace eth0 as udhcpc dns interface
+    sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
     echo -n "Running wpa_supplicant... "
     wpa_supplicant -B -Dnl80211,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,8 @@ packages="$packages e2fsprogs"
 packages="$packages f2fs-tools"
 packages="$packages gpgv"
 packages="$packages raspbian-archive-keyring"
+packages="$packages wpasupplicant"
+packages="$packages firmware-realtek"
 
 # libraries
 packages="$packages libblkid1"
@@ -27,6 +29,11 @@ packages="$packages libgcc1"
 packages="$packages liblzo2-2"
 packages="$packages libuuid1"
 packages="$packages zlib1g"
+packages="$packages libssl1.0.0"
+packages="$packages libdbus-1-3"
+packages="$packages libnl-3-200"
+packages="$packages libnl-genl-3-200"
+packages="$packages libpcsclite1"
 
 packages_found=
 packages_debs=
@@ -138,6 +145,8 @@ download_package_lists() {
     package_section=firmware
     download_package_list
     package_section=main
+    download_package_list
+    package_section=non-free
     download_package_list
 }
 

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,6 @@ packages="$packages f2fs-tools"
 packages="$packages gpgv"
 packages="$packages raspbian-archive-keyring"
 packages="$packages wpasupplicant"
-packages="$packages firmware-realtek"
 
 # libraries
 packages="$packages libblkid1"


### PR DESCRIPTION
User must add wpa_supplicant.conf file to /boot/config/ which is in wpa_supplicant-format, see man wpa_supplicant.conf.

Added following options and added it to readme
ifname - interface name used for network connection
wlandriver - filename of driver which is inserted into the kernel. This file must exist in the default installation.

Installation now includes wpa_supplicant and firmware-realtek package.
Directory /drivers/wireless holds wlan drivers