### PR TITLE
Updated readme.md to make more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ If you want to reinstall with the same settings you did your first install you c
 **Remember to backup all your data and original config.txt before doing this!**
 
 ## Installer customization
-While defaults should work for most power users, some might want to customize default configuration or the package set even further. The installer provides support for this by reading a configuration file `installer-config.txt` from the first vfat partition. The configuration file is read in as a shell script so you can abuse that fact if you so want to.
-See `scripts/etc/init.d/rcS` for more details what kind of environment your script will be run in (currently 'busybox sh').
+While defaults should work for most power users, some might want to customize default configuration or the package set even further. The installer provides support for this by reading a configuration file `installer-config.txt` from the first vfat partition. The configuration file is read in as a shell script so you can abuse that fact if you so want to. 
+See `scripts/etc/init.d/rcS` for more details what kind of environment your script will be run in (currently 'busybox sh'). 
 
 If an `installer-config.txt` file exists in the same directory as this `README.md`, it will be added to the installer image automatically.
 
@@ -135,7 +135,7 @@ The format of the file and the current defaults:
     rootfs_install_mount_options='noatime,data=writeback,nobarrier,noinit_itable'
     rootfs_mount_options='errors=remount-ro,noatime'
 
-All of the configuration options should be clear. You can override any of these in your _installer-config.txt_.  
+All of the configuration options should be clear. You can override any of these in your _installer-config.txt_ by placing your own `installer-config.txt` in the main directory.  
 The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
 **Note:** You only need to provide the options which you want to **override** in your _installer-config.txt_ file.  
 All non-provided options will use the defaults as mentioned above.


### PR DESCRIPTION
It was unclear to me that you could place the installer-config.txt on the sdcard without building your own install.  I tried to make it more clear. I think it just needs to be mentioned explicitly in the readme file. 