### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ When a new kernel becomes available in the archives and is installed, the system
 
 > Optional: `apt-get install raspi-copies-and-fills` for improved memory management performance.  
 > Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.
+> Optional: `apt-get install rng-tools` and add `bcm2708-rng` to `/etc/modules` to auto-load and use the kernel module for the hardware random number generator. This improves the performance of various server applications needing random numbers significantly.
 
 ## Reinstalling or replacing an existing system
 If you want to reinstall with the same settings you did your first install you can just move the original _config.txt_ back and reboot. Make sure you still have _kernel_install.img_ and _installer.cpio.gz_ in your _/boot_ partition. If you are replacing your existing system which was not installed using this method, make sure you copy those two files in and the installer _config.txt_ from the original image.


### PR DESCRIPTION
Added info about the hardware random number generator. An idle RPi usually generates very few bytes of entropy per minute which can cause high delays for crypto-intensive applications. With the hardware random number generator, /dev/random manages over 25kB/s.