### PR TITLE
Correcting variable replacement

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -53,7 +53,7 @@ fail()
         mount $bootpartition /boot
         fail_boot_mounted=true
     fi
-    cp $LOGFILE /boot/raspbian-ua-netinst-`date +%Y%m%dT%H%M%S`.log
+    cp -- $LOGFILE /boot/raspbian-ua-netinst-`date +%Y%m%dT%H%M%S`.log
     sync
     
     # if we mounted /boot in the fail command, unmount it.
@@ -146,7 +146,7 @@ echo -n "Copying boot files... "
 # copy boot data to safety
 mount $bootpartition /boot || fail
 
-cp -r /boot/* /bootfs/ || fail
+cp -r -- /boot/* /bootfs/ || fail
 
 umount /boot || fail
 echo "OK"
@@ -519,7 +519,7 @@ mount $bootpartition /rootfs/boot || fail
 echo "OK"
 
 echo -n "Copying /boot files in... "
-cp -r /bootfs/* /rootfs/boot || fail
+cp -r -- /bootfs/* /rootfs/boot || fail
 sync
 echo "OK"
 
@@ -743,9 +743,8 @@ for listfile in $(ls *.list)
 do
     if [ $listfile != "sources.list" ] ; then
         echo -n "  Copying $listfile to /etc/apt/sources.list.d/... "
-        cp $listfile /rootfs/etc/apt/sources.list.d/
-        # verify the file is indeed present in its target location
-        if [ -f /rootfs/etc/apt/sources.list.d/$listfile ] ; then
+        cp -- $listfile /rootfs/etc/apt/sources.list.d/
+        if [ $? -eq 0 ] ; then
             echo "OK"
         else
             echo "FAILED"
@@ -768,9 +767,8 @@ done
 for preffile in $(ls *.pref)
 do
     echo -n "  Copying $preffile to /etc/apt/preferences.d/... "
-    cp $preffile /rootfs/etc/apt/preferences.d/
-    # verify the file is indeed present in its target location
-    if [ -f /rootfs/etc/apt/preferences.d/$listfile ] ; then
+    cp -- $preffile /rootfs/etc/apt/preferences.d/
+    if [ $? -eq 0 ] ; then
         echo "OK"
     else
         echo "FAILED"
@@ -863,7 +861,7 @@ fi
 # make sure there is a /boot/kernel.img or /boot/kernel7.img present
 if [ ! -f /rootfs/boot/${default_kernel_file} ] ; then
     echo -n "Copying kernel to /boot/${default_kernel_file}... "
-    cp /rootfs/boot/vmlinuz-${KERNEL_VERSION} /rootfs/boot/${default_kernel_file}
+    cp -- /rootfs/boot/vmlinuz-${KERNEL_VERSION} /rootfs/boot/${default_kernel_file}
     if [ $? -eq 0 ]; then
         echo "OK"
     else
@@ -898,7 +896,7 @@ echo " and took $(($DURATION/60)) min $(($DURATION%60)) sec ($DURATION seconds)"
 
 echo -n "Unmounting filesystems... "
 # copy logfile to standard log directory
-cp $LOGFILE /rootfs/var/log/raspbian-ua-netinst.log
+cp -- $LOGFILE /rootfs/var/log/raspbian-ua-netinst.log
 chmod 0640 /rootfs/var/log/raspbian-ua-netinst.log
 
 umount /rootfs/boot

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -739,58 +739,33 @@ old_dir=$(pwd)
 cd /rootfs/boot/config/apt/
 
 # iterate through all the *.list files and add them to /etc/apt/sources.list.d
-for listfile in $(ls *.list)
+for listfile in ./*.list
 do
-    if [ $listfile != "sources.list" ] ; then
+    if [ "$listfile" != "sources.list" && -e "$listfile" ] ; then
         echo -n "  Copying $listfile to /etc/apt/sources.list.d/... "
-        cp -- $listfile /rootfs/etc/apt/sources.list.d/
-        if [ $? -eq 0 ] ; then
-            echo "OK"
-        else
-            echo "FAILED"
-        fi
-
-        if grep -l '__RELEASE__' /rootfs/etc/apt/sources.list.d/$listfile >/dev/null ; then
-            echo -n "  Replacing __RELEASE__ with $release in $listfile... "
-            sed -i "s/__RELEASE__/$release/" /rootfs/etc/apt/sources.list.d/$listfile
-            # if __RELEASE__ is still present, something went wrong
-            if grep -l '__RELEASE__' /rootfs/etc/apt/sources.list.d/$listfile >/dev/null ; then
-                echo "FAILED"
-            else
-                echo "OK"
-            fi
-        fi
+        sed "s/__RELEASE__/$release/g" "$listfile" > "/rootfs/etc/apt/sources.list.d/$listfile" || fail
+        echo "OK"
     fi
 done
 
 # iterate through all the *.pref files and add them to /etc/apt/preferences.d
-for preffile in $(ls *.pref)
+for preffile in ./*.pref
 do
-    echo -n "  Copying $preffile to /etc/apt/preferences.d/... "
-    cp -- $preffile /rootfs/etc/apt/preferences.d/
-    if [ $? -eq 0 ] ; then
+    if [ -e "$preffile" ]; then
+        echo -n "  Copying $preffile to /etc/apt/preferences.d/... "
+        sed "s/__RELEASE__/$release/g" "$preffile" > "/rootfs/etc/apt/preferences.d/$preffile" || fail
         echo "OK"
-    else
-        echo "FAILED"
-    fi
-
-    if grep -l '__RELEASE__' /rootfs/etc/apt/preferences.d/$preffile >/dev/null ; then
-        echo -n "  Replacing __RELEASE__ with $release in $preffile... "
-        sed -i "s/__RELEASE__/$release/" /rootfs/etc/apt/preferences.d/$preffile
-        # if __RELEASE__ is still present, something went wrong
-        if grep -l '__RELEASE__' /rootfs/etc/apt/sources.list.d/$listfile >/dev/null ; then
-            echo "FAILED"
-        else
-            echo "OK"
-        fi
     fi
 done
 
 # iterate through all the *.key files and add them to apt-key
-for keyfile in $(ls *.key)
+for keyfile in ./*.key
 do
-    echo "  Adding key $keyfile to apt."
-    cat $keyfile | chroot /rootfs /usr/bin/apt-key add -
+    if [ -e "$keyfile" ]; then
+        echo -n "  Adding key $keyfile to apt."
+        cat "$keyfile" | chroot /rootfs /usr/bin/apt-key add - || fail
+        echo "OK"
+    fi
 done
 
 # return to the old location for the rest of the processing

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -739,7 +739,7 @@ old_dir=$(pwd)
 cd /rootfs/boot/config/apt/
 
 # iterate through all the *.list files and add them to /etc/apt/sources.list.d
-for listfile in *.list
+for listfile in $(ls *.list)
 do
     if [ $listfile != "sources.list" ] ; then
         echo -n "  Copying $listfile to /etc/apt/sources.list.d/... "
@@ -764,7 +764,7 @@ do
 done
 
 # iterate through all the *.pref files and add them to /etc/apt/preferences.d
-for preffile in *.pref
+for preffile in $(ls *.pref)
 do
     echo -n "  Copying $preffile to /etc/apt/preferences.d/... "
     cp $preffile /rootfs/etc/apt/preferences.d/
@@ -787,7 +787,7 @@ do
 done
 
 # iterate through all the *.key files and add them to apt-key
-for keyfile in *.key
+for keyfile in $(ls *.key)
 do
     echo "  Adding key $keyfile to apt."
     cat $keyfile | chroot /rootfs /usr/bin/apt-key add -

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -744,7 +744,8 @@ do
     if [ $listfile != "sources.list" ] ; then
         echo -n "  Copying $listfile to /etc/apt/sources.list.d/... "
         cp $listfile /rootfs/etc/apt/sources.list.d/
-        if [ $? -eq ] ; then
+        # verify the file is indeed present in its target location
+        if [ -f /rootfs/etc/apt/sources.list.d/$listfile ] ; then
             echo "OK"
         else
             echo "FAILED"
@@ -768,7 +769,8 @@ for preffile in $(ls *.pref)
 do
     echo -n "  Copying $preffile to /etc/apt/preferences.d/... "
     cp $preffile /rootfs/etc/apt/preferences.d/
-    if [ $? -eq 0 ] ; then
+    # verify the file is indeed present in its target location
+    if [ -f /rootfs/etc/apt/preferences.d/$listfile ] ; then
         echo "OK"
     else
         echo "FAILED"


### PR DESCRIPTION
This pull corrects these issues:

```
Configuring apt:
  Copying raspbian repo to sources.list... OK
  Replacing __RELEASE__ with jessie... OK
  Adding raspberrypi.org gpg key to apt-key.
  Copying raspberrypi.org.list to /etc/apt/sources.list.d/... sh: -eq: argument expected
FAILED
  Copying 01vcgencmd.pref to /etc/apt/preferences.d/... OK
  Replacing __RELEASE__ with jessie in 01vcgencmd.pref... grep: /rootfs/etc/apt/sources.list.d/sources.list: No such file or directory
OK
  Adding key *.key to apt.
cat: can't open '*.key': No such file or directory
gpg: no valid OpenPGP data found.
```