### PR TITLE
Fixed the download of the raspberry.org GPG key to be from a secure URL.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -114,7 +114,7 @@ download_package_lists() {
         exit 1
     fi
     echo -e "\nDownloading and importing raspberrypi.gpg.key..."
-    curl -# -O http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
+    curl -# -O https://www.raspberrypi.org/raspberrypi.gpg.key
     gpg -q --homedir gnupg --import raspberrypi.gpg.key
     echo -n "Verifying raspberrypi.gpg.key... "
     if gpg --homedir gnupg -k 0xCF8A1AF502A2AA2D763BAE7E82B129927FA3303E &> /dev/null ; then


### PR DESCRIPTION
As ShiftPlusOne confirmed the key details via a signed message, posted
on http://pastebin.com/8UaWvHRZ and copied 'locally' here:
https://github.com/debian-pi/raspbian-ua-netinst/issues/64#issuecomment-99134357
I now consider the downloading of the raspberrypi.org signing key
secure.
This fixes issue #64.