### PR TITLE
Verify the number of imported GPG keys

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -106,31 +106,31 @@ download_package_lists() {
     curl -# -O https://archive.raspbian.org/raspbian.public.key
     gpg -q --homedir gnupg --import raspbian.public.key
     echo -n "Verifying raspbian.public.key... "
-    if gpg --homedir gnupg -k 0xA0DA38D0D76E8B5D638872819165938D90FDDD2E &> /dev/null ; then
-        echo "OK"
-    else
+    if ! gpg --homedir gnupg -k 0xA0DA38D0D76E8B5D638872819165938D90FDDD2E &> /dev/null ; then
         echo -e "ERROR\nBad GPG key fingerprint for raspbian.org!"
         cd ..
         exit 1
+    elif [ "$(gpg --homedir gnupg -k --with-colons | grep '^pub:' | wc -l)" -ne 1 ] ; then
+        echo -e "ERROR\nImported more than one GPG key for raspbian.org!"
+        cd ..
+        exit 1
+    else
+        echo "OK"
     fi
     echo -e "\nDownloading and importing raspberrypi.gpg.key..."
     curl -# -O https://www.raspberrypi.org/raspberrypi.gpg.key
     gpg -q --homedir gnupg --import raspberrypi.gpg.key
     echo -n "Verifying raspberrypi.gpg.key... "
-    if gpg --homedir gnupg -k 0xCF8A1AF502A2AA2D763BAE7E82B129927FA3303E &> /dev/null ; then
-        echo "OK"
-    else
+    if ! gpg --homedir gnupg -k 0xCF8A1AF502A2AA2D763BAE7E82B129927FA3303E &> /dev/null ; then
         echo -e "ERROR\nBad GPG key fingerprint for raspberrypi.org!"
         cd ..
         exit 1
-    fi
-    echo -e "\nVerifying that only two keys were imported..."
-    if [ "$(gpg --homedir gnupg -k --with-colons | grep '^pub:' | wc -l)" -eq 2 ]; then
-        echo "OK"
-    else
-        echo -e "ERROR\nImported more than two GPG keys!"
+    elif [ "$(gpg --homedir gnupg -k --with-colons | grep '^pub:' | wc -l)" -ne 2 ] ; then
+        echo -e "ERROR\nImported more than one GPG key for raspberrypi.org!"
         cd ..
         exit 1
+    else
+        echo "OK"
     fi
 
     echo -e "\nDownloading Release file and its signature..."

--- a/update.sh
+++ b/update.sh
@@ -124,6 +124,14 @@ download_package_lists() {
         cd ..
         exit 1
     fi
+    echo -e "\nVerifying that only two keys were imported..."
+    if [ "$(gpg --homedir gnupg -k --with-colons | grep '^pub:' | wc -l)" -eq 2 ]; then
+        echo "OK"
+    else
+        echo -e "ERROR\nImported more than two GPG keys!"
+        cd ..
+        exit 1
+    fi
 
     echo -e "\nDownloading Release file and its signature..."
     curl -# -O $mirror/dists/$release/Release -O $mirror/dists/$release/Release.gpg


### PR DESCRIPTION
The `--import` command can be used to import keyrings in addition to individual keys, so it is necessary to check that only the two desired keys were imported. (Subsequent signature verifications depend on only valid keys being in the default keyring.)

The current version is vulnerable to attackers who can MITM HTTPS connections, because the attacker could replace `raspbian.public.key` with a keyring containing both `raspbian.public.key` and the attacker's key, then sign malicious files with their own key. The `update.sh` script would check that `raspbian.public.key` was imported but not notice the presence of the attacker's key. This commit prevents this vulnerability by ensuring that only the two desired keys were imported.