### PR TITLE
Fixed bug in copying wireless drivers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -227,7 +227,7 @@ function create_cpio {
 
     # drivers
     mkdir -p rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net
-    cp -r tmp/lib/modules/*/kernel/drivers/net/wireless rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net/
+    cp -r tmp/lib/modules/$KERNEL_VERSION/kernel/drivers/net/wireless rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net/
 
     cd rootfs && find . | cpio -H newc -ov > ../installer-${target_system}.cpio
     cd ..


### PR DESCRIPTION
On cpio build, the drivers for both kernels (rpi1, rpi2) were mixed up