### PR TITLE
Remove hardcoded wheezy in sources.list

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -549,7 +549,7 @@ echo "OK"
 # add firmware to default apt sources
 echo -n "Configuring apt... "
 echo "deb http://mirrordirector.raspbian.org/raspbian $release main firmware" > /rootfs/etc/apt/sources.list
-echo "deb http://archive.raspberrypi.org/debian wheezy main" >> /rootfs/etc/apt/sources.list
+echo "deb http://archive.raspberrypi.org/debian $release main" >> /rootfs/etc/apt/sources.list
 cat /usr/share/keyrings/raspberrypi.gpg.key | chroot /rootfs /usr/bin/apt-key add - &>/dev/null
 echo "OK"
 


### PR DESCRIPTION
This reverts commit 3e5323a3726f1b94a75499de139bd65562f2c8ea.

archive.raspberrypi.org now supports jessie.

Conflicts:
	scripts/etc/init.d/rcS