### PR TITLE
Adding gzip compression of installer cpio files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -203,9 +203,8 @@ function create_cpio {
     # zlib1g components
     cp tmp/lib/*/libz.so.1  rootfs/lib/
 
-    cd rootfs && find . | cpio -H newc -ov > ../installer-${target_system}.cpio
-    cd ..
-    gzip -f --best installer-${target_system}.cpio
+    INITRAMFS="../installer-${target_system}.cpio.gz"
+    (cd rootfs && find . | cpio -H newc -ov | gzip --best > $INITRAMFS)
 
     rm -rf rootfs
 

--- a/build.sh
+++ b/build.sh
@@ -205,6 +205,7 @@ function create_cpio {
 
     cd rootfs && find . | cpio -H newc -ov > ../installer-${target_system}.cpio
     cd ..
+    gzip -f --best installer-${target_system}.cpio
 
     rm -rf rootfs
 
@@ -239,17 +240,17 @@ if [ ! -f bootfs/config.txt ] ; then
 fi
 
 create_cpio "rpi1"
-cp installer-rpi1.cpio bootfs/
+cp installer-rpi1.cpio.gz bootfs/
 echo "[pi1]" >> bootfs/config.txt
 echo "kernel=kernel-rpi1_install.img" >> bootfs/config.txt
-echo "initramfs installer-rpi1.cpio" >> bootfs/config.txt
+echo "initramfs installer-rpi1.cpio.gz" >> bootfs/config.txt
 echo "device_tree=" >> bootfs/config.txt
 
 create_cpio "rpi2"
-cp installer-rpi2.cpio bootfs/
+cp installer-rpi2.cpio.gz bootfs/
 echo "[pi2]" >> bootfs/config.txt
 echo "kernel=kernel-rpi2_install.img" >> bootfs/config.txt
-echo "initramfs installer-rpi2.cpio" >> bootfs/config.txt
+echo "initramfs installer-rpi2.cpio.gz" >> bootfs/config.txt
 
 # clean up
 rm -rf tmp

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm -rf bootfs rootfs firmware packages tmp installer*.cpio *.zip *.xz *.bz2 *.img
+rm -rf bootfs rootfs firmware packages tmp installer*.cpio installer*.cpio.gz *.zip *.xz *.bz2 *.img


### PR DESCRIPTION
When gzipped, the files are about half the size. This leaves more space in /boot.

See also #238