### PR TITLE
Add dependency to BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,6 @@ On a Debian system those are the following, excluding packages with priority ess
 - kpartx
 - dosfstools
 - binutils
-- bc
 
 The following scripts are used to build the raspbian-ua-netinst installer, listed in the same order they would be used:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -12,6 +12,7 @@ On a Debian system those are the following, excluding packages with priority ess
 - kpartx
 - dosfstools
 - binutils
+- bc
 
 The following scripts are used to build the raspbian-ua-netinst installer, listed in the same order they would be used:
 


### PR DESCRIPTION
we use bc in buildroot.sh, but it's not installed on a Ubuntu server 15.04 system