### PR TITLE
Improved output of checks by triggering the first invocation before we actually use it.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -86,7 +86,9 @@ setup_archive_keys() {
 
     mkdir -m 0700 -p gnupg
     # Let gpg set itself up already in the 'gnupg' dir before we actually use it
+    echo "Setting up gpg... "
     gpg --homedir gnupg --list-secret-keys
+    echo ""
 
     echo "Downloading ${RASPBIAN_ARCHIVE_KEY_FILE_NAME}."
     curl -# -O ${RASPBIAN_ARCHIVE_KEY_URL}

--- a/update.sh
+++ b/update.sh
@@ -86,7 +86,7 @@ setup_archive_keys() {
 
     mkdir -m 0700 -p gnupg
     # Let gpg set itself up already in the 'gnupg' dir before we actually use it
-    gpg -q --homedir gnupg --list-secret-keys &>/dev/null
+    gpg --homedir gnupg --list-secret-keys
 
     echo "Downloading ${RASPBIAN_ARCHIVE_KEY_FILE_NAME}."
     curl -# -O ${RASPBIAN_ARCHIVE_KEY_URL}

--- a/update.sh
+++ b/update.sh
@@ -85,6 +85,8 @@ check_key() {
 setup_archive_keys() {
 
     mkdir -m 0700 -p gnupg
+    # Let gpg set itself up already in the 'gnupg' dir before we actually use it
+    gpg -q --homedir gnupg --list-secret-keys &>/dev/null
 
     echo "Downloading ${RASPBIAN_ARCHIVE_KEY_FILE_NAME}."
     curl -# -O ${RASPBIAN_ARCHIVE_KEY_URL}


### PR DESCRIPTION
This just has a cosmetic effect.
Old output:
```
Checking key file 'raspbian.public.key'... gpg: keyring `gnupg/secring.gpg' created
gpg: keyring `gnupg/pubring.gpg' created
gpg: gnupg/trustdb.gpg: trustdb created
OK
Importing 'raspbian.public.key' into keyring... OK
```
New output:
```
Checking key file 'raspbian.public.key'... OK
Importing 'raspbian.public.key' into keyring... OK
```