### PR TITLE
Replaced 'wheezy' with __RELEASE__ for the raspberrypi.org repo.

### DIFF
--- a/config/apt/raspberrypi.org.list
+++ b/config/apt/raspberrypi.org.list
@@ -1,1 +1,1 @@
-deb http://archive.raspberrypi.org/debian wheezy main 
+deb http://archive.raspberrypi.org/debian __RELEASE__ main 


### PR DESCRIPTION
This is essentially the same change as commit
1dfa5f2b338e14df7d84b19bbcf278d0be1b48bc but adjusted for the 1.1.x branch.