### PR TITLE
build.sh: fix mkfs.btrfs path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,7 @@ function create_cpio {
 
 
     # btrfs-tools components
-    cp tmp/sbin/mkfs.btrfs rootfs/sbin/
+    cp tmp/bin/mkfs.btrfs rootfs/bin/
     cp tmp/usr/lib/*/libbtrfs.so.0  rootfs/lib/
 
     # busybox-static components


### PR DESCRIPTION
mkfs.btrfs binary is in */bin*, not in */sbin*.
Running build.sh was failing:
```bash
cp: cannot stat 'tmp/sbin/mkfs.btrfs': No such file or directory
```

With that change, it won't fail anymore.