### PR TITLE
Add a way to specify the target hardware to install for

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The format of the _installer&#8209;config.txt_ file and the current defaults:
     rootfs_mkfs_options=
     rootfs_install_mount_options='noatime,data=writeback,nobarrier,noinit_itable'
     rootfs_mount_options='errors=remount-ro,noatime'
+    hardware_versions=detect  # "detect" supports the install hardware only, set to "1 2" to produce an install that supports both Pi1 and Pi2
 
 The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -35,7 +35,7 @@ online_config=
 usbroot=
 cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
 rootfstype=ext4
-build_hardware_versions=detect
+hardware_versions=detect
 
 # these shouldn't really be changed unless auto-detection fails
 bootdev=/dev/mmcblk0
@@ -300,10 +300,10 @@ if [ "$online_config" != "" ]; then
     echo "================================================="
 fi
 
-if [ "$build_hardware_versions" = "detect" ]; then
+if [ "$hardware_versions" = "detect" ]; then
     case $rpi_hardware_version in
-        1) build_hardware_versions="1" ;;
-        2) build_hardware_versions="2" ;;
+        1) hardware_versions="1" ;;
+        2) hardware_versions="2" ;;
         *)
            echo ""
            echo "================================================="
@@ -312,7 +312,7 @@ if [ "$build_hardware_versions" = "detect" ]; then
            echo "          Building for both Pi and Pi 2.         "
            echo "================================================="
            echo ""
-           build_hardware_versions="1 2"
+           hardware_versions="1 2"
            ;;
     esac
 fi
@@ -365,7 +365,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
 
     # base
     base_packages="cpufrequtils,kmod"
-    for hv in ${build_hardware_versions}
+    for hv in ${hardware_versions}
     do
         case $hv in
             1) kernel_meta_package=linux-image-rpi-rpfv ;;
@@ -477,7 +477,7 @@ echo "  rootfstype = $rootfstype"
 echo "  rootfs_mkfs_options = $rootfs_mkfs_options"
 echo "  rootfs_install_mount_options = $rootfs_install_mount_options"
 echo "  rootfs_mount_options = $rootfs_mount_options"
-echo "  build_hardware_versions = $build_hardware_versions"
+echo "  hardware_versions = $hardware_versions"
 echo
 
 echo -n "Waiting 5 seconds"
@@ -870,7 +870,7 @@ if [ ! -f /rootfs/boot/config.txt ] ; then
     touch /rootfs/boot/config.txt
 fi
 
-for hv in ${build_hardware_versions}
+for hv in ${hardware_versions}
 do
     # find kernel/initramfs version
     eval kernel_meta_package=\${kernel_meta_package_${hv}}

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -35,6 +35,7 @@ online_config=
 usbroot=
 cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
 rootfstype=ext4
+build_hardware_versions=detect
 
 # these shouldn't really be changed unless auto-detection fails
 bootdev=/dev/mmcblk0
@@ -115,25 +116,28 @@ tee < ${LOGFILE}.pipe $LOGFILE &
 exec &> ${LOGFILE}.pipe
 rm ${LOGFILE}.pipe
 
-RPI1_HARDWARE="BCM2708"
-RPI2_HARDWARE="BCM2709"
 rpi_hardware=$(grep Hardware /proc/cpuinfo | cut -d " " -f 2)
-rpi_hardware_version="UNKNOWN !!"
-kernel_meta_package=""
+case $rpi_hardware in
+    BCM2708) rpi_hardware_version="1" ;;
+    BCM2709) rpi_hardware_version="2" ;;
+    *) rpi_hardware_version="unknown" ;;
+esac
 
-if [ "$rpi_hardware" = "$RPI1_HARDWARE" ] ; then
-    rpi_hardware_version="1"
-    kernel_meta_package="linux-image-rpi-rpfv"
-elif [ "$rpi_hardware" = "$RPI2_HARDWARE" ] ; then
-    rpi_hardware_version="2"
-    kernel_meta_package="linux-image-rpi2-rpfv"
-else
-    echo ""
-    echo "================================================="
-    echo "     No Raspberry Pi hardware detected!!"
-    echo " Value of rpi_hardware variable: '${rpi_hardware}'"
-    echo "================================================="
-    echo ""
+if [ "$build_hardware_versions" = "detect" ]; then
+    case $rpi_hardware_version in
+        1) build_hardware_versions="1" ;;
+        2) build_hardware_versions="2" ;;
+        *)
+           echo ""
+           echo "================================================="
+           echo "     No Raspberry Pi hardware detected!!"
+           echo " Value of rpi_hardware variable: '${rpi_hardware}'"
+           echo "          Building for both Pi and Pi 2.         "
+           echo "================================================="
+           echo ""
+           build_hardware_versions="1 2"
+           ;;
+    esac
 fi
 
 echo ""
@@ -143,6 +147,7 @@ echo "================================================="
 echo "Revision __VERSION__"
 echo "Built on __DATE__"
 echo "Running on Raspberry Pi version ${rpi_hardware_version}"
+echo "Building for Raspberry Pi versions ${build_hardware_versions}"
 echo "================================================="
 echo "https://github.com/debian-pi/raspbian-ua-netinst/"
 echo "================================================="
@@ -360,7 +365,29 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # base
-    base_packages="${kernel_meta_package},cpufrequtils,kmod"
+    base_packages="cpufrequtils,kmod"
+    for hv in ${build_hardware_versions}
+    do
+        case $hv in
+            1) kernel_meta_package=linux-image-rpi-rpfv ;;
+            2) kernel_meta_package=linux-image-rpi2-rpfv ;;
+            *)
+                echo ""
+                echo "================================================="
+                echo "  I don't understand a hardware version of ${hv} "
+                echo "    Skipping the kernel work for that hardware.  "
+                echo "================================================="
+                echo ""
+
+                kernel_meta_package=none ;;
+        esac
+
+        eval kernel_meta_package_${hv}=${kernel_meta_package}
+        if [ ${kernel_meta_package} != "none" ] ; then
+            base_packages="${kernel_meta_package},${base_packages}"
+        fi
+    done
+
     if [ "$init_system" = "systemd" ] ; then
         base_packages="${base_packages},libpam-systemd"
     fi
@@ -451,6 +478,7 @@ echo "  rootfstype = $rootfstype"
 echo "  rootfs_mkfs_options = $rootfs_mkfs_options"
 echo "  rootfs_install_mount_options = $rootfs_install_mount_options"
 echo "  rootfs_mount_options = $rootfs_mount_options"
+echo "  build_hardware_versions = $build_hardware_versions"
 echo
 
 echo -n "Waiting 5 seconds"
@@ -837,39 +865,47 @@ echo "snd-bcm2835" >> /rootfs/etc/modules
 echo "Configuring bootloader to start the installed system..."
 mv /rootfs/boot/config.txt /rootfs/boot/config-reinstall.txt
 
-# find kernel/initramfs version
-KERNEL_VERSION=$(sed -n -e "/^Package: ${kernel_meta_package}$/,/Package: /{s/^Depends: .*linux-image-\(.*-rpi2\{0,1\}\).*$/\1/p}" /rootfs/var/lib/dpkg/status)
-echo "Kernel version: '${KERNEL_VERSION}'"
-
 # no kernel-upgrade-script for the time being
 # just add the kernel/initramfs lines to /boot/config.txt for now
 if [ ! -f /rootfs/boot/config.txt ] ; then
     touch /rootfs/boot/config.txt
 fi
-echo "[pi${rpi_hardware_version}]" >> /rootfs/boot/config.txt
-echo "kernel=vmlinuz-$KERNEL_VERSION" >> /rootfs/boot/config.txt
-echo "initramfs initrd.img-${KERNEL_VERSION} followkernel" >> /rootfs/boot/config.txt
-if [ "${rpi_hardware_version}" = "1" ] ; then
-    echo "# to enable DeviceTree, comment out the next line " >> /rootfs/boot/config.txt
-    echo "device_tree=" >> /rootfs/boot/config.txt
-fi
 
-# set the default kernel file based on the hardware
-default_kernel_file="kernel.img"
-if [ "${rpi_hardware_version}" = "2" ] ; then
-    default_kernel_file="kernel7.img"
-fi
+for hv in ${build_hardware_versions}
+do
+    # find kernel/initramfs version
+    eval kernel_meta_package=\${kernel_meta_package_${hv}}
+    if [ ${kernel_meta_package} != "none" ]
+    then
+        KERNEL_VERSION=$(sed -n -e "/^Package: ${kernel_meta_package}$/,/Package: /{s/^Depends: .*linux-image-\(.*-rpi2\{0,1\}\).*$/\1/p}" /rootfs/var/lib/dpkg/status)
+        echo "Adding boot config for kernel version: '${KERNEL_VERSION}'"
 
-# make sure there is a /boot/kernel.img or /boot/kernel7.img present
-if [ ! -f /rootfs/boot/${default_kernel_file} ] ; then
-    echo -n "Copying kernel to /boot/${default_kernel_file}... "
-    cp -- /rootfs/boot/vmlinuz-${KERNEL_VERSION} /rootfs/boot/${default_kernel_file}
-    if [ $? -eq 0 ]; then
-        echo "OK"
-    else
-        echo "FAILED !"
+        echo "[pi${hv}]" >> /rootfs/boot/config.txt
+        echo "kernel=vmlinuz-$KERNEL_VERSION" >> /rootfs/boot/config.txt
+        echo "initramfs initrd.img-${KERNEL_VERSION} followkernel" >> /rootfs/boot/config.txt
+        if [ "${hv}" = "1" ] ; then
+            echo "# to enable DeviceTree, comment out the next line " >> /rootfs/boot/config.txt
+            echo "device_tree=" >> /rootfs/boot/config.txt
+        fi
+
+        # set the default kernel file based on the hardware
+        case ${hv} in
+            2) default_kernel_file="kernel7.img" ;;
+            *) default_kernel_file="kernel.img" ;;
+        esac
+
+        # make sure there is a /boot/kernel.img or /boot/kernel7.img present
+        if [ ! -f /rootfs/boot/${default_kernel_file} ] ; then
+            echo -n "Copying kernel to /boot/${default_kernel_file}... "
+            cp -- /rootfs/boot/vmlinuz-${KERNEL_VERSION} /rootfs/boot/${default_kernel_file}
+            if [ $? -eq 0 ]; then
+                echo "OK"
+            else
+                echo "FAILED !"
+            fi
+        fi
     fi
-fi
+done
 
 # default cmdline.txt
 echo -n "Creating default cmdline.txt... "

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -123,23 +123,6 @@ case $rpi_hardware in
     *) rpi_hardware_version="unknown" ;;
 esac
 
-if [ "$build_hardware_versions" = "detect" ]; then
-    case $rpi_hardware_version in
-        1) build_hardware_versions="1" ;;
-        2) build_hardware_versions="2" ;;
-        *)
-           echo ""
-           echo "================================================="
-           echo "     No Raspberry Pi hardware detected!!"
-           echo " Value of rpi_hardware variable: '${rpi_hardware}'"
-           echo "          Building for both Pi and Pi 2.         "
-           echo "================================================="
-           echo ""
-           build_hardware_versions="1 2"
-           ;;
-    esac
-fi
-
 echo ""
 echo "================================================="
 echo "raspbian-ua-netinst"
@@ -147,7 +130,6 @@ echo "================================================="
 echo "Revision __VERSION__"
 echo "Built on __DATE__"
 echo "Running on Raspberry Pi version ${rpi_hardware_version}"
-echo "Building for Raspberry Pi versions ${build_hardware_versions}"
 echo "================================================="
 echo "https://github.com/debian-pi/raspbian-ua-netinst/"
 echo "================================================="
@@ -316,6 +298,23 @@ if [ "$online_config" != "" ]; then
     source /online-config.txt
     echo "=== Finished executing online-config.txt. ==="
     echo "================================================="
+fi
+
+if [ "$build_hardware_versions" = "detect" ]; then
+    case $rpi_hardware_version in
+        1) build_hardware_versions="1" ;;
+        2) build_hardware_versions="2" ;;
+        *)
+           echo ""
+           echo "================================================="
+           echo "     No Raspberry Pi hardware detected!!"
+           echo " Value of rpi_hardware variable: '${rpi_hardware}'"
+           echo "          Building for both Pi and Pi 2.         "
+           echo "================================================="
+           echo ""
+           build_hardware_versions="1 2"
+           ;;
+    esac
 fi
 
 # prepare rootfs mount options


### PR DESCRIPTION
This allows configuring the Pi version to target from the installer config, and also allows targetting both Pi1 & Pi2 together. (I am using the installer to build an installed image that will then be run on many different machines, so it needs to support both).

Should cover #194 too.