### PR TITLE
Allow poweroff or halt after installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The format of the _installer&#8209;config.txt_ file and the current defaults:
     rootfs_mkfs_options=
     rootfs_install_mount_options='noatime,data=writeback,nobarrier,noinit_itable'
     rootfs_mount_options='errors=remount-ro,noatime'
+    final_action=reboot  # set to poweroff to poweroff/halt at the end of the install rather than rebooting.
 
 The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The format of the _installer&#8209;config.txt_ file and the current defaults:
     rootfs_mkfs_options=
     rootfs_install_mount_options='noatime,data=writeback,nobarrier,noinit_itable'
     rootfs_mount_options='errors=remount-ro,noatime'
-    final_action=reboot  # set to poweroff to poweroff/halt at the end of the install rather than rebooting.
+    final_action=reboot  # what to do at the end of install, one of poweroff / halt / reboot
 
 The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -911,6 +911,9 @@ case ${final_action} in
     poweroff)
         echo -n "Finished! Powering off in 5 seconds..."
         ;;
+    halt)
+        echo -n "Finished! Halting in 5 seconds..."
+        ;;
     *)
         echo -n "Finished! Rebooting to installed system in 5 seconds..."
         final_action=reboot

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -35,6 +35,7 @@ online_config=
 usbroot=
 cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
 rootfstype=ext4
+final_action=reboot
 
 # these shouldn't really be changed unless auto-detection fails
 bootdev=/dev/mmcblk0
@@ -451,6 +452,7 @@ echo "  rootfstype = $rootfstype"
 echo "  rootfs_mkfs_options = $rootfs_mkfs_options"
 echo "  rootfs_install_mount_options = $rootfs_install_mount_options"
 echo "  rootfs_mount_options = $rootfs_mount_options"
+echo "  final_action = $final_action"
 echo
 
 echo -n "Waiting 5 seconds"
@@ -905,11 +907,19 @@ umount /rootfs/boot
 umount /rootfs
 echo "OK"
 
-echo -n "Finished! Rebooting to installed system in 5 seconds..."
+case ${final_action} in
+    poweroff)
+        echo -n "Finished! Powering off in 5 seconds..."
+        ;;
+    *)
+        echo -n "Finished! Rebooting to installed system in 5 seconds..."
+        final_action=reboot
+esac
+
 for i in `seq 5 -1 1`; do
     sleep 1
 
     echo -n "$i.. "
 done
-echo " rebooting now"
-reboot
+echo " now"
+${final_action}


### PR DESCRIPTION
This lets you specify what to do at the end of the install (reboot / poweroff / halt).
Useful when using the installer to build an installed image; you don't want to actually boot into the installed system before you've taken a copy of the installed image.