### PR TITLE
Added check for existence of file before operating on it.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -565,7 +565,7 @@ echo "OK"
 
 # openssh-server in jessie doesn't allow root to login using password anymore
 # this hack does allow it (until a proper solution is implemented)
-if [ "$release" = "jessie" ] ; then
+if [ "$release" = "jessie" ] && [ -f /rootfs/etc/ssh/sshd_config ] ; then
     echo -n "  Allowing root to login with password... "
     sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /rootfs/etc/ssh/sshd_config || fail
     echo "OK"


### PR DESCRIPTION
The 'base' preset doesn't install the ssh-server package and thus also
doesn't have the sshd_config file.