### PR TITLE
Added 'contrib' to the archive areas list and reordered the sequence.

### DIFF
--- a/config/apt/sources.list
+++ b/config/apt/sources.list
@@ -1,1 +1,1 @@
-deb http://mirrordirector.raspbian.org/raspbian __RELEASE__ main firmware non-free
+deb http://mirrordirector.raspbian.org/raspbian __RELEASE__ main contrib non-free firmware


### PR DESCRIPTION
Components from 'non-free' may need programs from contrib, thus add it.
The new ordering is also more logical/standard.