### PR TITLE
Fixed error in security setting swap file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The latest kernel and firmware packages are now automatically installed during t
 When you need a kernel module that isn't loaded by default, you will still have to configure that manually.
 
 > Optional: `apt-get install raspi-copies-and-fills` for improved memory management performance.  
-> Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap && chown og-r /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.  
+> Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap && chmod 600 /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.  
 > Optional: `apt-get install rng-tools` and add `bcm2708-rng` to `/etc/modules` to auto-load and use the kernel module for the hardware random number generator. This improves the performance of various server applications needing random numbers significantly.
 
 ## Reinstalling or replacing an existing system


### PR DESCRIPTION
It should be 'chmod', not 'chown'. Thanks to gitdings for bringing it to
our attention.