### PR TITLE
Sleep before unmounting to make the logfile more likely to be complete.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -933,10 +933,12 @@ DURATION=$(($ENDTIME - $REAL_STARTTIME))
 echo -n "Installation finished at $(date --date="@$ENDTIME" --utc)"
 echo " and took $(($DURATION/60)) min $(($DURATION%60)) sec ($DURATION seconds)"
 
-echo -n "Unmounting filesystems... "
 # copy logfile to standard log directory
+sleep 1
 cp -- $LOGFILE /rootfs/var/log/raspbian-ua-netinst.log
 chmod 0640 /rootfs/var/log/raspbian-ua-netinst.log
+
+echo -n "Unmounting filesystems... "
 
 umount /rootfs/boot
 umount /rootfs


### PR DESCRIPTION
The problem is that the tee might not have finished writing out the end of the logfile when the copy/umount happens. I find it usually cuts off at least the "installation finished at .." line.

This is a bit of a bandaid - the "right" solution would be to preserve the original console fds at the start of the install, switch back to them at the end, close the pipe and wait for the tee to exit - but it's much simpler and seems to work OK.