### PR TITLE
Add dosfstools to minimal packages for fsck.vfat.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -393,7 +393,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # minimal
-    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server"
+    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools"
 
     # server
     server_packages="vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,less,man-db"


### PR DESCRIPTION
Without fsck.vfat, fsck of /boot is silently skipped on boot.