### PR TITLE
Check for existence of locale files/programs before operating on them.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -799,27 +799,35 @@ if [ "$locales" != "" ]; then
     echo -n "  Enabling locales... "
     for locale in $locales; do
         echo -n "$locale... "
-        if [ $(grep -c $locale /rootfs/etc/locale.gen) -gt 0 ]; then
+        if [ -f /rootfs/etc/locale.gen ] && [ $(grep -c $locale /rootfs/etc/locale.gen) -gt 0 ]; then
             sed -i "s/^# \($locale .*\)/\1/" /rootfs/etc/locale.gen
         else
             echo -n "NOT found... "
         fi
     done
     echo "OK"
-    chroot /rootfs /usr/sbin/locale-gen | sed 's/^/  /'
-    if [ $? -ne 0 ]; then
-        echo "  ERROR while generating locales !"
+    if [ -x /rootfs/usr/sbin/locale-gen ] ; then
+        chroot /rootfs /usr/sbin/locale-gen | sed 's/^/  /'
+        if [ $? -ne 0 ]; then
+            echo "  ERROR while generating locales !"
+        fi
+    else
+        echo "Not generating locales as the 'locales' package isn't installed !"
     fi
 fi
 
 # set system default locale
-if [ "$system_default_locale" != "" ]; then
-    echo -n "  Setting system default locale... "
-    chroot /rootfs /usr/sbin/update-locale LANG="$system_default_locale" &> /dev/null
-    if [ $? -eq 0 ]; then
-        echo "OK"
+if [ "$system_default_locale" != "" ] ; then
+    if [ -x /rootfs/usr/sbin/update-locale ] ; then
+        echo -n "  Setting system default locale... "
+        chroot /rootfs /usr/sbin/update-locale LANG="$system_default_locale" &> /dev/null
+        if [ $? -eq 0 ]; then
+            echo "OK"
+        else
+            echo "FAILED !"
+        fi
     else
-        echo "FAILED !"
+        echo "NOT setting system default locale as the 'locale' package isn't installed !"
     fi
 fi
 


### PR DESCRIPTION
Turns out it was only needed on files related to locales.
I thought also about `date +"%Y-%m-%d %H:%M:%S" > /rootfs/etc/fake-hwclock.data`, but decided against it as it won't generate an error (`fake-hwclock` may not be installed).