### PR TITLE
Added 'drivers/net/usb' to support network devices over usb.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -495,6 +495,7 @@ function create_cpio {
     # drivers
     mkdir -p rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net
     cp -r tmp/lib/modules/$KERNEL_VERSION/kernel/drivers/net/wireless rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net/
+    cp -r tmp/lib/modules/$KERNEL_VERSION/kernel/drivers/net/usb rootfs/lib/modules/$KERNEL_VERSION/kernel/drivers/net/
 
     INITRAMFS="../installer-${target_system}.cpio.gz"
     (cd rootfs && find . | cpio -H newc -ov | gzip --best > $INITRAMFS)


### PR DESCRIPTION
There are various network devices which run over USB, besides wireless,
and they should now work too. Probably (also) useful for the Pi Zero.