### PR TITLE
Changed Pin condition to 'c=firmware' as that is a better differentiator.

### DIFF
--- a/config/apt/01vcgencmd.pref
+++ b/config/apt/01vcgencmd.pref
@@ -1,4 +1,4 @@
 Package: libraspberrypi-bin libraspberrypi0 libraspberrypi-dev libraspberrypi-doc
-Pin: release o=Raspbian,n=__RELEASE__
+Pin: release o=Raspbian,c=firmware
 Pin-Priority: 800
 


### PR DESCRIPTION
The 'n' (name) parameter doesn't distinguish between the raspbian.org repo 
and the raspberrypi.org repo as they both have wheezy and jessie.
But in the raspberrypi.org repo it is contained in the 'main' section
whereas it is in the firmware section of raspbian.org.
Bonus side effect is that if you switch to stretch (=current testing)
after having installed jessie first, then it still works.