### PR TITLE
HWRNG support (v1.0.x) with `rng-tools` installed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
 
 INSTALL_MODULES="kernel/fs/f2fs/f2fs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/fs/btrfs/btrfs.ko"
+INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/char/hw_random/bcm2708-rng.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/usb/storage/usb-storage.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sd_mod.ko"

--- a/build.sh
+++ b/build.sh
@@ -197,6 +197,12 @@ function create_cpio {
     # raspbian-archive-keyring components
     cp tmp/usr/share/keyrings/raspbian-archive-keyring.gpg rootfs/usr/share/keyrings/
 
+    # rng-tools components
+    cp tmp/usr/bin/rngtest rootfs/usr/bin/
+    cp tmp/usr/sbin/rngd rootfs/usr/sbin/
+    cp tmp/etc/default/rng-tools rootfs/etc/default/
+    cp tmp/etc/init.d/rng-tools rootfs/etc/init.d/
+    
     # libblkid1 components
     cp tmp/lib/*/libblkid.so.1.1.0 rootfs/lib/libblkid.so.1
 

--- a/build.sh
+++ b/build.sh
@@ -196,6 +196,12 @@ function create_cpio {
 
     # raspbian-archive-keyring components
     cp tmp/usr/share/keyrings/raspbian-archive-keyring.gpg rootfs/usr/share/keyrings/
+    
+    # rng-tools components
+    cp tmp/usr/bin/rngtest rootfs/usr/bin/
+    cp tmp/usr/sbin/rngd rootfs/usr/sbin/
+    cp tmp/etc/default/rng-tools rootfs/etc/default/
+    cp tmp/etc/init.d/rng-tools rootfs/etc/init.d/
 
     # libblkid1 components
     cp tmp/lib/*/libblkid.so.1.1.0 rootfs/lib/libblkid.so.1

--- a/build.sh
+++ b/build.sh
@@ -196,12 +196,6 @@ function create_cpio {
 
     # raspbian-archive-keyring components
     cp tmp/usr/share/keyrings/raspbian-archive-keyring.gpg rootfs/usr/share/keyrings/
-    
-    # rng-tools components
-    cp tmp/usr/bin/rngtest rootfs/usr/bin/
-    cp tmp/usr/sbin/rngd rootfs/usr/sbin/
-    cp tmp/etc/default/rng-tools rootfs/etc/default/
-    cp tmp/etc/init.d/rng-tools rootfs/etc/init.d/
 
     # libblkid1 components
     cp tmp/lib/*/libblkid.so.1.1.0 rootfs/lib/libblkid.so.1

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -631,6 +631,7 @@ fi
 
 # add reasonable default modules, works only after kernel is properly installed
 echo "snd-bcm2835" >> /rootfs/etc/modules
+echo "bcm2708-rng" >> /rootfs/etc/modules
 
 echo "Configuring bootloader to start the installed system..."
 mv /rootfs/boot/config.txt /rootfs/boot/config-reinstall.txt

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -148,6 +148,7 @@ if [ $? -eq 0 ]; then
 else
     echo "FAILED! (continuing to use the software RNG)"
 fi
+/etc/init.d/rng-tools start
 
 if [ -e /bootfs/installer-config.txt ]; then
     echo "================================================="

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -148,7 +148,6 @@ if [ $? -eq 0 ]; then
 else
     echo "FAILED! (continuing to use the software RNG)"
 fi
-/etc/init.d/rng-tools start
 
 if [ -e /bootfs/installer-config.txt ]; then
     echo "================================================="
@@ -325,7 +324,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # minimal
-    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,rng-tools"
+    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server"
 
     # server
     server_packages="vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,less,man-db"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -324,7 +324,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # minimal
-    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server"
+    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,rng-tools"
 
     # server
     server_packages="vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,less,man-db"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -144,9 +144,9 @@ echo "OK"
 echo -n "Starting HWRNG "
 modprobe bcm2708-rng
 if [ $? -eq 0 ]; then
-  echo "succeeded!"
+    echo "succeeded!"
 else
-  echo "FAILED!"
+    echo "FAILED! (continuing to use the software RNG)"
 fi
 
 if [ -e /bootfs/installer-config.txt ]; then

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -141,6 +141,14 @@ cp -r /boot/* /bootfs/ || fail
 umount /boot || fail
 echo "OK"
 
+echo -n "Starting HWRNG "
+modprobe bcm2708-rng
+if [ $? -eq 0 ]; then
+  echo "succeeded!"
+else
+  echo "FAILED!"
+fi
+
 if [ -e /bootfs/installer-config.txt ]; then
     echo "================================================="
     echo "=== Start executing installer-config.txt. ==="

--- a/update.sh
+++ b/update.sh
@@ -34,6 +34,7 @@ packages+=("lsb-base")
 packages+=("netbase")
 packages+=("ntpdate")
 packages+=("raspbian-archive-keyring")
+packages+=("rng-tools")
 
 # libraries
 packages+=("libblkid1")

--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,6 @@ packages+=("lsb-base")
 packages+=("netbase")
 packages+=("ntpdate")
 packages+=("raspbian-archive-keyring")
-packages+=("rng-tools")
 
 # libraries
 packages+=("libblkid1")


### PR DESCRIPTION
Tests suggest that `rng-tools` is needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/debian-pi/raspbian-ua-netinst/361)
<!-- Reviewable:end -->
