### PR TITLE
Add 'resolvconf' package to 'minimal' preset

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -400,7 +400,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # minimal
-    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools"
+    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools,resolvconf"
 
     # server
     server_packages="vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,less,man-db"


### PR DESCRIPTION
With IPv6 support in place, there can be two dynamic sources of
recursive DNS server information in the system. To handle this,
install the 'resolvconf' package which will coordinate updates.