### PR TITLE
Add 'rdisc6' to initramfs for IPv6 DNS server discovery

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -297,6 +297,9 @@ function create_cpio {
     cd ../../../..
     cp tmp/usr/sbin/arpd rootfs/usr/sbin/
 
+    # ndisc6 components
+    cp tmp/bin/rdisc6 rootfs/bin
+
     # lsb-base components
     cp tmp/lib/lsb/init-functions rootfs/lib/lsb/
     cp tmp/lib/lsb/init-functions.d/20-left-info-blocks rootfs/lib/lsb/init-functions.d/

--- a/update.sh
+++ b/update.sh
@@ -40,6 +40,7 @@ packages+=("raspbian-archive-keyring")
 packages+=("tar")
 packages+=("util-linux")
 packages+=("wpasupplicant")
+packages+=("ndisc6")
 
 # libraries
 packages+=("libacl1")


### PR DESCRIPTION
IPv6 networks commonly use RDNSS, inside Router Advertisements,
to communicate the addresses of recursive DNS servers to hosts
on the network. This patch adds the rdisc6 tool so the installer
script can obtain the addresses.

A follow-up pull request will change the script to actually use the tool.