### PR TITLE
Run alternative rcS, if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Presets set the `cdebootstrap_cmdline` variable. For example, the current _serve
 
 (If you build your own installer, which most won't need to, and the configuration files exist in the same directory as this `README.md`, it will be include in the installer image automatically.)
 
+### Custom installer script
+
+It is possible to replace the installer script completely, without rebuilding the installer image. To do this, place a custom `rcS` file in the config directory of your SD card. The installer script will check this location and run this script instead of itself. Take great care when doing this, as it is intended to be used for development purposes.
+
+Should you still choose to go this route, please use the original [rcs](https://github.com/debian-pi/raspbian-ua-netinst/blob/master/scripts/etc/init.d/rcS) file as a starting point.
+
 ## Logging
 The output of the installation process is now also logged to file.  
 When the installation completes successfully, the logfile is moved to /var/log/raspbian-ua-netinst.log on the installed system.  

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -121,7 +121,7 @@ klogd -c 1
 # Check if there's an alternative rcS file and excute it
 # instead of this file. Only do this if this isn't the
 # alternative script already
-if [ -z ${am_subshell} ]; then
+if [ -z ${am_subscript} ]; then
     mkdir -p /boot
     mount $bootpartition /boot
     if [ -e /boot/config/rcS ]; then
@@ -130,7 +130,7 @@ if [ -z ${am_subshell} ]; then
         echo "============================================="
         echo "=== Start executing alternative rcS ========="
         echo "---------------------------------------------"
-        export am_subshell=true
+        export am_subscript=true
         source /rcS
         echo "---------------------------------------------"
         echo "=== Execution of alternative rcS finished ==="

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -118,6 +118,30 @@ mdev -s
 
 klogd -c 1
 
+# Check if there's an alternative rcS file and excute it
+# instead of this file. Only do this if this isn't the
+# alternative script already
+if [ -z ${am_subshell} ]; then
+    mkdir -p /boot
+    mount $bootpartition /boot
+    if [ -e /boot/config/rcS ]; then
+        cp /boot/config/rcS /rcS
+        umount /boot
+        echo "============================================="
+        echo "=== Start executing alternative rcS ========="
+        echo "---------------------------------------------"
+        export am_subshell=true
+        source /rcS
+        echo "---------------------------------------------"
+        echo "=== Execution of alternative rcS finished ==="
+        echo "============================================="
+        ${final_action} || reboot || exit
+    else
+        # Clean up, so the rest of the script continues as expected
+        umount /boot
+    fi
+fi
+
 # redirect stdout and stderr also to logfile
 # http://stackoverflow.com/questions/3173131/redirect-copy-of-stdout-to-log-file-from-within-bash-script-itself/6635197#6635197
 mkfifo ${LOGFILE}.pipe

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -124,8 +124,8 @@ klogd -c 1
 if [ -z ${am_subscript} ]; then
     mkdir -p /boot
     mount $bootpartition /boot
-    if [ -e /boot/config/rcS ]; then
-        cp /boot/config/rcS /rcS
+    if [ -e /boot/config/installer/rcS ]; then
+        cp /boot/config/installer/rcS /rcS
         umount /boot
         echo "============================================="
         echo "=== Start executing alternative rcS ========="


### PR DESCRIPTION
If a `rcS` file is found in the config directory of the SD card, the installer (`rcS`) script will execute that file instead of itself.
This allows for much easier installer development, as there is no need to rebuild the installer image every time a change needs to be tested.

As a side effect, it also allows end users to add to (or change) the installer script without a need to rebuild the image.