### PR TITLE
Add check for existing lo interface

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -528,7 +528,13 @@ echo "OK"
 # default hostname
 echo -n "  Configuring hostname... "
 echo -n $hostname > /rootfs/etc/hostname || fail
-echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
+if [ ! -f /rootfs/etc/hosts ]; then
+    echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
+else
+    if ! grep -q "localhost" /rootfs/etc/hosts; then
+        echo "127.0.0.1	localhost" >> /rootfs/etc/hosts
+    fi
+fi
 if [ "$domainname" = "" ]; then
      echo "127.0.1.1	$hostname" >> /rootfs/etc/hosts || fail
 else

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -537,10 +537,13 @@ fi
 echo "OK"
 
 # networking
+# wheezy seems to add the lo interface, so first check for it
 echo -n "  Configuring network settings... "
-echo "auto lo" > /rootfs/etc/network/interfaces || fail
-echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces || fail
-echo "" >>  /rootfs/etc/network/interfaces || fail
+if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
+    echo "auto lo" > /rootfs/etc/network/interfaces || fail
+    echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces || fail
+    echo "" >>  /rootfs/etc/network/interfaces || fail
+fi
 
 # eth0 config
 echo "auto eth0" >> /rootfs/etc/network/interfaces || fail


### PR DESCRIPTION
It seems Wheezy adds a lo interface to `/etc/network/interfaces`, this PR adds a check, which prevents the script from adding another one in such case