### PR TITLE
elevator=noop

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -34,7 +34,7 @@ ip_nameservers=
 drivers_to_load=
 online_config=
 usbroot=
-cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=deadline"
+cmdline="dwc_otg.lpm_enable=0 console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty1 elevator=noop"
 rootfstype=ext4
 final_action=reboot
 hardware_versions=detect


### PR DESCRIPTION
Use `elevator=noop` i.s.o. `elevator=deadline` because `noop` is more efficient for SD cards.
Ref:
- https://superuser.com/questions/542740/linux-kernel-scheduler-for-a-pen-drive-noop-or-deadline
- http://forum.xda-developers.com/showpost.php?s=b236833a23a9d84f6f1b863c120ccda7&p=23616564&postcount=4
.

I've been using this setting for several months on different Pi's with no problems.