### PR TITLE
Add trailing newline to /etc/hostname

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -527,7 +527,7 @@ echo "OK"
 
 # default hostname
 echo -n "  Configuring hostname... "
-echo -n $hostname > /rootfs/etc/hostname || fail
+echo $hostname > /rootfs/etc/hostname || fail
 if [ ! -f /rootfs/etc/hosts ]; then
     echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
 else


### PR DESCRIPTION
This one is related to #388 but fixed the hostname issue for v1.0.x
It adds a trailing newline (well, just removed the option that prevented it from being created) to `/etc/hostname`