### PR TITLE
No sound

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1016,8 +1016,6 @@ if [ "$ifname" != "eth0" ]; then
     fi
 fi
 
-# add reasonable default modules, works only after kernel is properly installed
-echo "snd-bcm2835" >> /rootfs/etc/modules
 if [ "$hwrng_support" = "1" ]; then
     echo "bcm2708-rng" >> /rootfs/etc/modules
 fi


### PR DESCRIPTION
Not loading the module `snd-bcm2835` by default.
Minimal systems do not require this module.
