### PR TITLE
wpa_supplicant usage

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1117,6 +1117,15 @@ if [ -e /bootfs/post-install.txt ]; then
     echo "================================================="
 fi
 
+# modify installed network settings
+if [ -f /rootfs/etc/wpa_supplicant/wpa_supplicant.conf ]; then
+    if [ $(grep "iface" /rootfs/etc/network/interfaces |grep -v "lo\|eth0" |wc -l) -ne 0 ]; then
+        if [ $(grep "wpa[-_]" /rootfs/etc/network/interfaces |wc -l) -eq 0 ]; then
+            echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf" >> /rootfs/etc/network/interfaces
+        fi
+    fi
+fi
+
 # remove cdebootstrap-helper-rc.d which prevents rc.d scripts from running
 echo -n "Removing cdebootstrap-helper-rc.d... "
 chroot /rootfs /usr/bin/dpkg -r cdebootstrap-helper-rc.d &>/dev/null || fail

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -838,29 +838,43 @@ echo "OK"
 # networking
 echo -n "  Configuring network settings... "
 touch /rootfs/etc/network/interfaces || fail
-{
-    # wheezy seems to add the lo interface, so first check for it
-    if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
-        echo "auto lo"
-        echo "iface lo inet loopback"
-        echo ""
-    fi
+# lo interface may already be there, so first check for it
+if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
+    echo "auto lo"                      >> /rootfs/etc/network/interfaces
+    echo "iface lo inet loopback"       >> /rootfs/etc/network/interfaces
+    echo ""                             >> /rootfs/etc/network/interfaces
+fi
 
-    # eth0 config
-    echo "auto $ifname"
-    if [ "$ip_addr" = "dhcp" ]; then
-        echo "iface $ifname inet dhcp"
+# eth0 config
+echo "auto $ifname"                     >> /rootfs/etc/network/interfaces
+if [ "$ip_addr" = "dhcp" ]; then
+    echo "iface $ifname inet dhcp"      >> /rootfs/etc/network/interfaces
+else
+    echo "iface $ifname inet static"    >> /rootfs/etc/network/interfaces
+    echo "    address $ip_addr"         >> /rootfs/etc/network/interfaces
+    echo "    netmask $ip_netmask"      >> /rootfs/etc/network/interfaces
+    echo "    broadcast $ip_broadcast"  >> /rootfs/etc/network/interfaces
+    echo "    gateway $ip_gateway"      >> /rootfs/etc/network/interfaces
+fi
+
+# wlan config
+if [ "$ifname" != "eth0" ]; then
+    # Install wireless dependencies
+    echo -n "Installing wpasupplicant package... "
+    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant >& /dev/null
+    if [ $? -eq 0 ]; then
+        echo "OK"
     else
-        echo "iface $ifname inet static"
-        echo "    address $ip_addr"
-        echo "    netmask $ip_netmask"
-        echo "    broadcast $ip_broadcast"
-        echo "    gateway $ip_gateway"
+        echo "FAILED !"
     fi
-    if [ "$ifname" != "eth0" ]; then
-        echo "wpa-conf /boot/config/wpa_supplicant.conf"
+    # 
+    if [ -e /bootfs/config/wpa_supplicant.conf ]; then
+        # copy the installer version of `wpa_supplicant.conf`
+        cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
     fi
-} >> /rootfs/etc/network/interfaces || fail
+    echo "wpa-conf /boot/config/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
+fi
+
 
 if [ "${disable_predictable_nin}" = "1" ]; then
     # as described here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames
@@ -1024,18 +1038,6 @@ if [ $? -eq 0 ]; then
     echo "OK"
 else
     echo "FAILED !"
-fi
-
-# if eth0 was not used during initial boot, a wireless interface was used
-if [ "$ifname" != "eth0" ]; then
-    # Install wireless dependencies
-    echo -n "Installing wpasupplicant package... "
-    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant >& /dev/null
-    if [ $? -eq 0 ]; then
-        echo "OK"
-    else
-        echo "FAILED !"
-    fi
 fi
 
 if [ "$hwrng_support" = "1" ]; then

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -866,6 +866,7 @@ fi
 if [ "$ifname" != "eth0" ]; then
     # Install wireless dependencies
     echo -n "Installing wpasupplicant package... "
+    mkdir -p /rootfs/etc/wpa_supplicant/
     chroot /rootfs /usr/bin/apt-get -y install wpasupplicant >& /dev/null
     if [ $? -eq 0 ]; then
         echo "OK"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -842,14 +842,15 @@ touch /rootfs/etc/network/interfaces || fail
 if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
     echo "auto lo" >> /rootfs/etc/network/interfaces
     echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces
-    echo  >> /rootfs/etc/network/interfaces
 fi
 
 # eth0 config
 echo "auto $ifname" >> /rootfs/etc/network/interfaces
 if [ "$ip_addr" = "dhcp" ]; then
+    echo  >> /rootfs/etc/network/interfaces
     echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces
 else
+    echo  >> /rootfs/etc/network/interfaces
     echo "iface $ifname inet static" >> /rootfs/etc/network/interfaces
     echo "    address $ip_addr" >> /rootfs/etc/network/interfaces
     echo "    netmask $ip_netmask" >> /rootfs/etc/network/interfaces

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -842,7 +842,7 @@ touch /rootfs/etc/network/interfaces || fail
 if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
     echo "auto lo" >> /rootfs/etc/network/interfaces
     echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces
-    echo ""  >> /rootfs/etc/network/interfaces
+    echo  >> /rootfs/etc/network/interfaces
 fi
 
 # eth0 config

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -840,21 +840,21 @@ echo -n "  Configuring network settings... "
 touch /rootfs/etc/network/interfaces || fail
 # lo interface may already be there, so first check for it
 if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
-    echo "auto lo"                      >> /rootfs/etc/network/interfaces
-    echo "iface lo inet loopback"       >> /rootfs/etc/network/interfaces
-    echo ""                             >> /rootfs/etc/network/interfaces
+    echo "auto lo" >> /rootfs/etc/network/interfaces
+    echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces
+    echo ""  >> /rootfs/etc/network/interfaces
 fi
 
 # eth0 config
-echo "auto $ifname"                     >> /rootfs/etc/network/interfaces
+echo "auto $ifname" >> /rootfs/etc/network/interfaces
 if [ "$ip_addr" = "dhcp" ]; then
-    echo "iface $ifname inet dhcp"      >> /rootfs/etc/network/interfaces
+    echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces
 else
-    echo "iface $ifname inet static"    >> /rootfs/etc/network/interfaces
-    echo "    address $ip_addr"         >> /rootfs/etc/network/interfaces
-    echo "    netmask $ip_netmask"      >> /rootfs/etc/network/interfaces
-    echo "    broadcast $ip_broadcast"  >> /rootfs/etc/network/interfaces
-    echo "    gateway $ip_gateway"      >> /rootfs/etc/network/interfaces
+    echo "iface $ifname inet static" >> /rootfs/etc/network/interfaces
+    echo "    address $ip_addr" >> /rootfs/etc/network/interfaces
+    echo "    netmask $ip_netmask" >> /rootfs/etc/network/interfaces
+    echo "    broadcast $ip_broadcast" >> /rootfs/etc/network/interfaces
+    echo "    gateway $ip_gateway" >> /rootfs/etc/network/interfaces
 fi
 
 # wlan config

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -875,7 +875,7 @@ if [ "$ifname" != "eth0" ]; then
     if [ -e /bootfs/config/wpa_supplicant.conf ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
-        echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
+        echo "    wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
     fi
 fi
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -275,7 +275,7 @@ if [ "$ifname" != "eth0" ]; then
     echo "Starting wpa_supplicant... "
     wpa_supplicant -B -Dnl80211 -c/bootfs/config/wpa_supplicant.conf -i$ifname
     if [ $? -ne 0 ]; then
-        echo "nl80211 driver is not working. Trying generic driver (wext)..."
+        echo "nl80211 driver didn't work. Trying generic driver (wext)..."
         wpa_supplicant -B -Dwext -c/bootfs/config/wpa_supplicant.conf -i$ifname || fail
         echo "OK"
     fi

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -858,12 +858,11 @@ if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
 fi
 
 # eth0 config
+echo "" >> /rootfs/etc/network/interfaces
 echo "auto $ifname" >> /rootfs/etc/network/interfaces
 if [ "$ip_addr" = "dhcp" ]; then
-    echo  >> /rootfs/etc/network/interfaces
     echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces
 else
-    echo  >> /rootfs/etc/network/interfaces
     echo "iface $ifname inet static" >> /rootfs/etc/network/interfaces
     echo "    address $ip_addr" >> /rootfs/etc/network/interfaces
     echo "    netmask $ip_netmask" >> /rootfs/etc/network/interfaces

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -272,13 +272,13 @@ if [ "$ifname" != "eth0" ]; then
     # Replace eth0 as udhcpc dns interface
     sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
-    echo -n "Running wpa_supplicant... "
-    if [ "$drivers_to_load" = "" ] ; then
-      # select linux default wireless driver if not configured by user
-      drivers_to_load=nl80211
+    echo -n "Starting wpa_supplicant... "
+    wpa_supplicant -B -Dnl80211 -c/bootfs/config/wpa_supplicant.conf -i$ifname
+    if [ $? -ne 0 ]; then
+        echo "nl80211 driver is not working. Trying generic driver (wext)..."
+        wpa_supplicant -B -Dwext -c/bootfs/config/wpa_supplicant.conf -i$ifname || fail
+        echo "OK"
     fi
-    wpa_supplicant -B -D$drivers_to_load,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail
-    echo "OK"
 fi
 
 if [ "$ip_addr" = "dhcp" ]; then
@@ -879,7 +879,6 @@ if [ "$ifname" != "eth0" ]; then
         echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
     fi
 fi
-
 
 if [ "${disable_predictable_nin}" = "1" ]; then
     # as described here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -872,7 +872,7 @@ if [ "$ifname" != "eth0" ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
     fi
-    echo "wpa-conf /boot/config/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
+    echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
 fi
 
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -272,7 +272,7 @@ if [ "$ifname" != "eth0" ]; then
     # Replace eth0 as udhcpc dns interface
     sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
-    echo -n "Starting wpa_supplicant... "
+    echo "Starting wpa_supplicant... "
     wpa_supplicant -B -Dnl80211 -c/bootfs/config/wpa_supplicant.conf -i$ifname
     if [ $? -ne 0 ]; then
         echo "nl80211 driver is not working. Trying generic driver (wext)..."

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -413,6 +413,15 @@ case "$rootfstype" in
     ;;
 esac
 
+# check if we need wpasupplicant package
+if [ "$ifname" != "eth0" ]; then
+    if [ -z "$packages" ]; then
+        packages="wpasupplicant"
+    else
+        packages="$packages,wpasupplicant"
+    fi
+fi
+
 # check if we need the sudo package and add it if so
 if [ "$user_is_admin" = "1" ]; then
     if [ -z "$packages" ]; then
@@ -864,15 +873,6 @@ fi
 
 # wlan config
 if [ "$ifname" != "eth0" ]; then
-    # Install wireless dependencies
-    echo -n "Installing wpasupplicant package... "
-    mkdir -p /rootfs/etc/wpa_supplicant/
-    chroot /rootfs /usr/bin/apt-get -y install wpasupplicant >& /dev/null
-    if [ $? -eq 0 ]; then
-        echo "OK"
-    else
-        echo "FAILED !"
-    fi
     if [ -e /bootfs/config/wpa_supplicant.conf ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -871,8 +871,8 @@ if [ "$ifname" != "eth0" ]; then
     if [ -e /bootfs/config/wpa_supplicant.conf ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
+        echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
     fi
-    echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
 fi
 
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -413,7 +413,7 @@ case "$rootfstype" in
     ;;
 esac
 
-# check if we need wpasupplicant package
+# check if we need to install wpasupplicant package
 if [ "$ifname" != "eth0" ]; then
     if [ -z "$packages" ]; then
         packages="wpasupplicant"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -877,9 +877,7 @@ if [ "$ifname" != "eth0" ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
         echo "    wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
-        echo "    allow-hotplug $ifname" >> /rootfs/etc/network/interfaces
     fi
-else
     echo "" >> /rootfs/etc/network/interfaces
     echo "auto eth0" >> /rootfs/etc/network/interfaces
     echo "allow-hotplug eth0" >> /rootfs/etc/network/interfaces

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -273,7 +273,7 @@ if [ "$ifname" != "eth0" ]; then
     sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
     echo -n "Running wpa_supplicant... "
-    wpa_supplicant -B -Dnl80211,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail
+    wpa_supplicant -B -D$drivers_to_load,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail
     echo "OK"
 fi
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -857,9 +857,10 @@ if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
     echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces
 fi
 
-# eth0 config
+# configured interface
 echo "" >> /rootfs/etc/network/interfaces
 echo "auto $ifname" >> /rootfs/etc/network/interfaces
+echo "allow-hotplug $ifname" >> /rootfs/etc/network/interfaces
 if [ "$ip_addr" = "dhcp" ]; then
     echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces
 else
@@ -876,7 +877,13 @@ if [ "$ifname" != "eth0" ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
         echo "    wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
+        echo "    allow-hotplug $ifname" >> /rootfs/etc/network/interfaces
     fi
+else
+    echo "" >> /rootfs/etc/network/interfaces
+    echo "auto eth0" >> /rootfs/etc/network/interfaces
+    echo "allow-hotplug eth0" >> /rootfs/etc/network/interfaces
+    echo "iface eth0 inet dhcp" >> /rootfs/etc/network/interfaces
 fi
 
 if [ "${disable_predictable_nin}" = "1" ]; then

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -868,7 +868,6 @@ if [ "$ifname" != "eth0" ]; then
     else
         echo "FAILED !"
     fi
-    # 
     if [ -e /bootfs/config/wpa_supplicant.conf ]; then
         # copy the installer version of `wpa_supplicant.conf`
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1122,8 +1122,8 @@ fi
 
 # modify installed network settings
 if [ -f /rootfs/etc/wpa_supplicant/wpa_supplicant.conf ]; then
-    if [ $(grep "iface" /rootfs/etc/network/interfaces |grep -v "lo\|eth0" |wc -l) -ne 0 ]; then
-        if [ $(grep "wpa[-_]" /rootfs/etc/network/interfaces |wc -l) -eq 0 ]; then
+    if [ $(grep "iface" /rootfs/etc/network/interfaces | grep -v "lo\|eth0" | wc -l) -ne 0 ]; then
+        if [ $(grep "wpa[-_]" /rootfs/etc/network/interfaces | wc -l) -eq 0 ]; then
             echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf" >> /rootfs/etc/network/interfaces
         fi
     fi

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -273,6 +273,10 @@ if [ "$ifname" != "eth0" ]; then
     sed -i "s/PEERDNS_IF=.*/PEERDNS_IF=$ifname/g" /etc/udhcpc/default.script
     # if eth0 is not the chosen eth interface it is a wireless interface and wpa_supplicant must connect to wlan
     echo -n "Running wpa_supplicant... "
+    if [ "$drivers_to_load" = "" ] ; then
+      # select linux default wireless driver if not configured by user
+      drivers_to_load=nl80211
+    fi
     wpa_supplicant -B -D$drivers_to_load,wext -c/bootfs/config/wpa_supplicant.conf -i$ifname >& /dev/null || fail
     echo "OK"
 fi


### PR DESCRIPTION
Changes:
  1. Put all networking related code together.
  2. If `config/wpa_supplicant.conf` exists AND was used by the installer then copy it to the installed system in `/etc/wpa_supplicant/` and add a reference to it in `/etc/network/interfaces`.
  3. Changed the way of installing and starting `wpa_supplicant` so that it actually works.

This commit will allow the user to **install** AND **use** the target system in the absence of a wired ethernet connection, but in the presence of a WiFi network.

The user must configure the following (already existing) parameters:
  1. `drivers_to_load=` supply the name of the module that must be loaded by the kernel for the hardware (WiFi dongle) used. _E.g.: `8192cu`_.
  1. `ifname=` supply the non-ethernet interface name. Normally you will use `wlan0` here.  

Additionally user must supply a file (`config/wpa_supplicant.conf`) containing a valid configuration. E.g.:  
> network={
>        ssid="pi3.1415926"
>        psk="AV3ry53cretPa55w0rdThatN00n3W!113verGue55"
>        key_mgmt=WPA-PSK
> }

ref: https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf
(Please don't use the password suggested in the example above. It is not secure)