### PR TITLE
Kernel 4.4 update

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,8 @@ set -e
 KERNEL_VERSION_RPI1=4.4.0-1-rpi
 KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
-INSTALL_MODULES="kernel/fs/f2fs/f2fs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/fs/btrfs/btrfs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/char/hw_random/bcm2708-rng.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/usb/storage/usb-storage.ko"
+INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sd_mod.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
 INSTALL_MODULES="kernel/fs/f2fs/f2fs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/fs/btrfs/btrfs.ko"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -192,7 +192,6 @@ echo "https://github.com/debian-pi/raspbian-ua-netinst/"
 echo "================================================="
 
 echo -n "Starting HWRNG "
-modprobe bcm2708-rng
 /usr/sbin/rngd -r /dev/hwrng
 if [ $? -eq 0 ]; then
     echo "succeeded!"
@@ -1046,10 +1045,6 @@ if [ $? -eq 0 ]; then
     echo "OK"
 else
     echo "FAILED !"
-fi
-
-if [ "$hwrng_support" = "1" ]; then
-    echo "bcm2708-rng" >> /rootfs/etc/modules
 fi
 
 # (conditionaly) enable hardware watchdog and set up systemd to use it

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
 RASPBIAN_ARCHIVE_KEY_DIRECTORY="https://archive.raspbian.org"
 RASPBIAN_ARCHIVE_KEY_FILE_NAME="raspbian.public.key"


### PR DESCRIPTION
Currently you can't build an installer that boots due to incompatibility between the new firmware files and the 3.18 kernel. This PR fixes that.