### PR TITLE
Update kernel version to 4.4

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,11 @@
 
 set -e
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
-INSTALL_MODULES="kernel/fs/f2fs/f2fs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/fs/btrfs/btrfs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/usb/storage/usb-storage.ko"
+INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sd_mod.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
 RASPBIAN_ARCHIVE_KEY_DIRECTORY="https://archive.raspbian.org"
 RASPBIAN_ARCHIVE_KEY_FILE_NAME="raspbian.public.key"


### PR DESCRIPTION
New kernel from the Raspbian archive.
Tested on Raspberry Pi 2.
Had to remove some INSTALL_MODULES-lines for modules listed in the built-in file.
I didn't edit CHANGELOG, I thought you'd like to vet the pull request first.