### PR TITLE
Add dosfstools to base_packages

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -442,7 +442,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
     fi
 
     # base
-    base_packages="cpufrequtils,kmod"
+    base_packages="cpufrequtils,kmod,dosfstools"
     for hv in ${hardware_versions}
     do
         case $hv in


### PR DESCRIPTION
Package `dosfstools` should be added to base_packages because mmcblk0p1 is FAT formatted.
`util-linux`, which is included in `linux-base` and includes `fsck` compatibility for `ext4`. So I think `dosfstools` is placed correctly in base_packages.