### PR TITLE
Remove note about installing rng-tools as hwrng_support is on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ When you need a kernel module that isn't loaded by default, you will still have 
 
 > Optional: `apt-get install raspi-copies-and-fills` for improved memory management performance.  
 > Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap && chmod 600 /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.  
-> Optional: `apt-get install rng-tools` and add `bcm2708-rng` to `/etc/modules` to auto-load and use the kernel module for the hardware random number generator. This improves the performance of various server applications needing random numbers significantly.
 
 ## Reinstalling or replacing an existing system
 If you want to reinstall with the same settings you did your first install you can just move the original _config.txt_ back and reboot. Depending on the hardware you want to reinstall on (Raspberry Pi **1** or **2**), make sure you still have _kernel_rpi1_install.img_ / _kernel_rpi2_install.img_ and _installer-rpi1.cpio.gz_ / _installer-rpi2.cpio.gz_ in your _/boot_ partition. If you are replacing your existing system which was not installed using this method, make sure you copy those files in and the installer _config.txt_ from the original image.


### PR DESCRIPTION
If the user has not overridden it, hwrng_support is on by default, and the
rng-tools package will be installed. In addition, in current kernels the
hwrng driver is in the kernel, not delivered as a module. If the user *has*
overridden the hwrng_support default, they don't need a note about how to
install rng-tools because they presumably did that on purpose :-)