### PR TITLE
Add IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ For those unfamiliar with IPv6 networking, there are some significant difference
 IPv6 networks can provide automatic addressing, automatic gateway discovery, and automatic DNS resolver discovery, but these can be provided
 independently. As a result, configuration of the installer for IPv6 is done in three parts.
 
+The simplest configuration is when the network supports SLAAC and RDNSS; this is roughly equivalent to IPv4 DHCP, and the installer will be
+able to automatically assign an address, gateway, and get DNS resolver address(es).
+
 #### Addressing
 
 The installer can be configured in three modes:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The default for IPv4 is to use DHCP to obtain an address/prefix, default gateway
 ### IPv6
 
 The default for IPv6 is to disable its use; even if the network advertises IPv6 information, it will not be used. Note that DHCPv6 is *not*
-supported, as there is no suitable DHCPv6 client available for us in the installer environment. If the network indicates that DHCPv6 is required
+supported, as there is no suitable DHCPv6 client available for use in the installer environment. If the network indicates that DHCPv6 is required
 for addressing or any other network information, the installer will not use IPv6. The installed system can use DHCPv6, but the installer
 is unable to configure it in that mode.
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ modes:
   do not provide DNS resolution over IPv6.
 
 ## Logging
-The output of the installation process is now also logged to file.
+The output of the installation process is now also logged to file.  
 When the installation completes successfully, the logfile is moved to /var/log/raspbian-ua-netinst.log on the installed system.  
 When an error occurs during install, the logfile is moved to the sd card, which gets normally mounted on /boot/ and will be named raspbian-ua-netinst-\<datetimestamp\>.log
 
@@ -300,8 +300,8 @@ The system is almost completely unconfigured on first boot. Here are some tasks 
 The default **root** password is **raspbian**.
 
 > Set new root password: `passwd`  (can also be set during installation using **rootpw** in [installer-config.txt](#installer-customization))  
-> Configure your default locale: `dpkg-reconfigure locales`
-> Configure your timezone: `dpkg-reconfigure tzdata`
+> Configure your default locale: `dpkg-reconfigure locales`  
+> Configure your timezone: `dpkg-reconfigure tzdata`  
 
 The latest kernel and firmware packages are now automatically installed during the unattended installation process.
 When you need a kernel module that isn't loaded by default, you will still have to configure that manually.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Writing the installer to the SD card](#writing-the-installer-to-the-sd-card)
 - [Installing](#installing)
 - [Installer customization](#installer-customization)
+- [IP Networking](#ip-networking)
 - [Logging](#logging)
 - [First boot](#first-boot)
 - [Reinstalling or replacing an existing system](#reinstalling-or-replacing-an-existing-system)
@@ -141,11 +142,14 @@ The format of the _installer-config.txt_ file and the current defaults:
                               # RPi board, your network device might be named differently. This will result in the
                               # board having no network connectivity.
     ifname=eth0
-    ip_addr=dhcp
-    ip_netmask=0.0.0.0
-    ip_broadcast=0.0.0.0
-    ip_gateway=0.0.0.0
-    ip_nameservers=
+    ip4_addr=dhcp # options are 'disable', 'dhcp', or an IPv4 address
+    ip4_prefixlength=0
+    ip4_gateway=0.0.0.0
+    ip4_nameservers=
+    ip6_addr=disable # options are 'disable', 'auto', or an IPv6 address
+    ip6_prefixlength=0
+    ip6_gateway=auto # options are 'auto', or an IPv6 address (which will only be applied if ip6_addr is a static address)
+    ip6_nameservers=auto # options are 'auto', 'disable', or an IPv6 address
     drivers_to_load=
     online_config=            # URL to extra config that will be executed after installer-config.txt
     usbroot=                  # set to 1 to install to first USB disk
@@ -190,6 +194,97 @@ Please be aware that some restrictions may apply to the sum of the file sizes. I
 It is possible to replace the installer script completely, without rebuilding the installer image. To do this, place a custom `rcS` file in the config directory of your SD card. The installer script will check this location and run this script instead of itself. Take great care when doing this, as it is intended to be used for development purposes.
 
 Should you still choose to go this route, please use the original [rcs](https://github.com/debian-pi/raspbian-ua-netinst/blob/master/scripts/etc/init.d/rcS) file as a starting point.
+
+## IP Networking
+
+The installer supports both IPv4 and IPv6 networking, although the default configuration is to use only IPv4. Networking can be configured using the 'ip4' and 'ip6'
+options in the installer-config.txt file (details below), and the configuration will be replicated into the installed system.
+
+If the installer cannot configure at least one IP address (either IPv4 or IPv6) it will abort, as networking is required to perform the installation.
+
+### IPv4
+
+The default for IPv4 is to use DHCP to obtain an address/prefix, default gateway, and DNS resolver(s). The installer can be configured in three IPv4 modes:
+
+- DHCP
+
+  Set 'ip4_addr' to 'dhcp'. The remaining 'ip4' configuration options will be ignored if set.
+
+- Static
+
+  Set 'ip4_addr' to an IPv4 address, and 'ip4_prefixlength' to the appropriate value for your network (the most common prefix length is 24, which corresponds to
+  a netmask of 255.255.255.0). Set 'ip4_gateway' to the address of the default gateway, and 'ip4_nameservers' to the address of the DNS resolver which should be used (if
+  there are multiple DNS resolvers, their addresses can be included in this option, separated by spaces).
+
+- Disabled
+
+  Set 'ip4_addr' to 'disable'. The remaining 'ip4' configuration options will be ignored if set.
+  
+### IPv6
+
+The default for IPv6 is to disable its use; even if the network advertises IPv6 information, it will not be used. Note that DHCPv6 is *not*
+supported, as there is no suitable DHCPv6 client available for us in the installer environment. If the network indicates that DHCPv6 is required
+for addressing or any other network information, the installer will not use IPv6. The installed system can use DHCPv6, but the installer
+is unable to configure it in that mode.
+
+For those unfamiliar with IPv6 networking, there are some significant differences from IPv4, in addition to the size of addresses. Most importantly,
+IPv6 networks can provide automatic addressing, automatic gateway discovery, and automatic DNS resolver discovery, but these can be provided
+independently. As a result, configuration of the installer for IPv6 is done in three parts.
+
+#### Addressing
+
+The installer can be configured in three modes:
+
+- Automatic
+
+  Set 'ip6_addr' to 'auto'. 'ip6_prefixlength' will be ignored if set. In this mode, the kernel will use incoming Router Advertisements
+  to determine network prefix information, and will use SLAAC (RFC 4862 - IPv6 Stateless Address Autoconfiguration) to generate an address.
+  If no RAs are received, or they do not contain on-link prefixes, the kernel will be unable to generate an address, and IPv6 support will be
+  disabled.
+
+- Static
+
+  Set 'ip6_addr' to an IPv6 address, and 'ip6_prefixlength' to the appropriate value for your network (the most common prefix length is 64). In
+  this mode any network prefixes received in RAs will be ignored.
+
+- Disabled
+
+  Set 'ip6_addr' to 'disable'. The remaining 'ip6' configuration options will be ignored if set.
+  
+#### Gateways
+
+IPv6 networks nearly always distribute gateway (router) addresses via Router Advertisements, as IPv6 routers typically use link-local addresses
+which can be dynamically changed. However, the installer does support static configuration. There are two configuration modes:
+
+- Automatic
+
+  Set 'ip6_gateway' to 'auto'. In this mode the kernel will determine gateway(s) to use based on Router Advertisements it receives.
+
+- Static
+
+  Set 'ip6_gateway' to an IPv6 address. In this mode any gateway addresses received in RAs will be ignored.
+
+#### DNS Resolvers
+
+Some IPv6 networks distribute DNS resolver information in Router Advertisements, using RDNSS (RFC 6106 - IPv6 Router Advertisment Options for
+DNS Configuration); others require static configuration, or do not provide DNS resolution via IPv6. The installer can be configured in three
+modes:
+
+- Automatic
+
+  Set 'ip6_nameservers' to 'auto'. In this mode the system will determine DNS resolver(s) to use based on Router Advertisements it receives.
+  Note that this mode requires the 'rdnssd' package, which provides a daemon to process the RDNSS options in the RAs, so this package will be
+  added to the installed system.
+
+- Static
+
+  Set 'ip6_nameservers' to the address of the DNS resolver which should be used (if there are multiple DNS resolvers, their addresses
+  can be included in this option, separated by spaces).
+
+- Disabled
+
+  Set 'ip6_nameservers' to 'disable'. This is only necessary to stop the installer from installing the 'rdnssd' package on networks which
+  do not provide DNS resolution over IPv6.
 
 ## Logging
 The output of the installation process is now also logged to file.  

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The default for IPv4 is to use DHCP to obtain an address/prefix, default gateway
 - Disabled
 
   Set 'ip4_addr' to 'disable'. The remaining 'ip4' configuration options will be ignored if set.
-  
+
 ### IPv6
 
 The default for IPv6 is to disable its use; even if the network advertises IPv6 information, it will not be used. Note that DHCPv6 is *not*
@@ -250,7 +250,7 @@ The installer can be configured in three modes:
 - Disabled
 
   Set 'ip6_addr' to 'disable'. The remaining 'ip6' configuration options will be ignored if set.
-  
+
 #### Gateways
 
 IPv6 networks nearly always distribute gateway (router) addresses via Router Advertisements, as IPv6 routers typically use link-local addresses
@@ -287,7 +287,7 @@ modes:
   do not provide DNS resolution over IPv6.
 
 ## Logging
-The output of the installation process is now also logged to file.  
+The output of the installation process is now also logged to file.
 When the installation completes successfully, the logfile is moved to /var/log/raspbian-ua-netinst.log on the installed system.  
 When an error occurs during install, the logfile is moved to the sd card, which gets normally mounted on /boot/ and will be named raspbian-ua-netinst-\<datetimestamp\>.log
 
@@ -297,8 +297,8 @@ The system is almost completely unconfigured on first boot. Here are some tasks 
 The default **root** password is **raspbian**.
 
 > Set new root password: `passwd`  (can also be set during installation using **rootpw** in [installer-config.txt](#installer-customization))  
-> Configure your default locale: `dpkg-reconfigure locales`  
-> Configure your timezone: `dpkg-reconfigure tzdata`  
+> Configure your default locale: `dpkg-reconfigure locales`
+> Configure your timezone: `dpkg-reconfigure tzdata`
 
 The latest kernel and firmware packages are now automatically installed during the unattended installation process.
 When you need a kernel module that isn't loaded by default, you will still have to configure that manually.

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
 INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
+INSTALL_MODULES="$INSTALL_MODULES kernel/net/ipv6/ipv6.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found
@@ -295,6 +296,9 @@ function create_cpio {
     ln -s m_xt.so m_ipt.so
     cd ../../../..
     cp tmp/usr/sbin/arpd rootfs/usr/sbin/
+
+    # ndisc6 components
+    cp tmp/bin/rdisc6 rootfs/bin
 
     # lsb-base components
     cp tmp/lib/lsb/init-functions rootfs/lib/lsb/

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -27,11 +27,14 @@ locales=
 system_default_locale=
 disable_predictable_nin=1
 ifname=eth0
-ip_addr=dhcp
-ip_netmask=0.0.0.0
-ip_broadcast=0.0.0.0
-ip_gateway=0.0.0.0
-ip_nameservers=
+ip4_addr=dhcp
+ip4_prefixlength=0
+ip4_gateway=0.0.0.0
+ip4_nameservers=
+ip6_addr=disable
+ip6_prefixlength=0
+ip6_gateway=auto
+ip6_nameservers=auto
 drivers_to_load=
 online_config=
 usbroot=
@@ -238,15 +241,52 @@ if [ -e /bootfs/config/wpa_supplicant.conf ]; then
     sanitize_inputfile /bootfs/config/wpa_supplicant.conf
 fi
 
+# Provide backwards compatibility for v1.0 configurations which used
+# "ip_" prefix instead of "ip4_"
+
+if [ ! -z "$ip_addr" ]; then
+   ip4_addr="$ip_addr"
+fi
+
+if [ ! -z "$ip_gateway" ]; then
+   ip4_gateway="$ip_gateway"
+fi
+
+if [ ! -z "$ip_nameservers" ]; then
+   ip4_nameservers="$ip_nameservers"
+fi
+
+# Provide backwards compatibility for v1.0 configurations which used
+# "ip_netmask" instead of "ip4_prefixlength"
+
+if [ ! -z "$ip_netmask" ]; then
+   ip4_prefixlength=$(ipcalc -p 255.255.255.255 $ip_netmask | cut -d= -f2)
+fi
+
 echo
 echo "Network configuration:"
-echo "  ip_addr = $ip_addr"
+echo "  ip4_addr = $ip4_addr"
 
-if [ "$ip_addr" != "dhcp" ]; then
-    echo "  ip_netmask = $ip_netmask"
-    echo "  ip_broadcast = $ip_broadcast"
-    echo "  ip_gateway = $ip_gateway"
-    echo "  ip_nameservers = $ip_nameservers"
+if [ "$ip4_addr" = "disable" ]; then
+    # nothing to do, just pass
+    :
+elif [ "$ip4_addr" != "dhcp" ]; then
+    echo "  ip4_prefixlength = $ip4_prefixlength"
+    echo "  ip4_gateway = $ip4_gateway"
+    echo "  ip4_nameservers = $ip4_nameservers"
+fi
+
+echo "  ip6_addr = $ip6_addr"
+
+if [ "$ip6_addr" = "disable" ]; then
+    # nothing to do, just pass
+    :
+elif [ "$ip6_addr" = "auto" ]; then
+    echo "  ip6_nameservers = $ip6_nameservers"
+else
+    echo "  ip6_prefixlength = $ip6_prefixlength"
+    echo "  ip6_gateway = $ip6_gateway"
+    echo "  ip6_nameservers = $ip6_nameservers"
 fi
 
 echo "  online_config = $online_config"
@@ -297,25 +337,148 @@ if [ "$ifname" != "eth0" ]; then
     fi
 fi
 
-if [ "$ip_addr" = "dhcp" ]; then
-    echo -n "Configuring $ifname with DHCP... "
+echo "OK"
+
+# do some IPv6 configuration which must be done before the
+# network interface is brought up
+if [ "$ip6_addr" != "disable" ]; then
+    modprobe ipv6
+    if [ "$ip6_addr" != "auto" ]; then
+        if [ "$ip6_gateway" != "auto" ]; then
+            # disable the acceptance of incoming Router Advertisement (RA)
+            # messages, otherwise the kernel might automatically add routes
+            echo 0 > /proc/sys/net/ipv6/conf/$ifname/accept_ra
+        else
+            # disable automatic generation of IPv6 addresses, which the kernel
+            # will do when it receives a suitable RA
+            echo 0 > /proc/sys/net/ipv6/conf/$ifname/autoconf
+	fi
+    fi
+fi
+
+ip link set lo up
+ip link set $ifname up
+
+touch /etc/resolv.conf
+if [ "$ip4_addr" = "disable" ]; then
+    # if IPv4 is disabled, configure the DNS resolver in glibc
+    # to prefer IPv6 addresses (by performing AAAA lookups
+    # before A lookups)
+    echo "options inet6" >> /etc/resolv.conf
+elif [ "$ip4_addr" = "dhcp" ]; then
+    echo -n "Configuring $ifname for IPv4 using DHCP... "
 
     udhcpc -i $ifname &>/dev/null
     if [ $? -eq 0 ]; then
-        ifconfig $ifname | fgrep addr: | awk '{print $2}' | cut -d: -f2
+        have_ip4=$(ip -4 addr ls $ifname | grep 'scope global' | awk '{print $2}')
+	echo $have_ip4
     else
         echo "FAILED"
-        fail
     fi
 else
-    echo -n "Configuring $ifname with static ip $ip_addr... "
-    ifconfig $ifname up inet $ip_addr netmask $ip_netmask broadcast $ip_broadcast || fail
-    route add default gw $ip_gateway || fail
-    echo -n > /etc/resolv.conf
-    for i in $ip_nameservers; do
+    echo -n "Configuring $ifname for IPv4 using static $ip4_addr... "
+    ip addr add $ip4_addr/$ip4_prefixlength dev $ifname || fail
+    ip route add default via $ip4_gateway || fail
+    for i in $ip4_nameservers; do
         echo "nameserver $i" >> /etc/resolv.conf
     done
+    have_ip4=$ip4_addr
     echo "OK"
+fi
+
+if [ "$ip6_addr" != "disable" ]; then
+    echo -n "Waiting for IPv6 link-local address on $ifname... "
+
+    for i in $(seq 1 10); do
+        if ip -6 addr show dev $ifname scope link | grep -q 'scope link'; then
+            break
+        fi
+
+        if [ $i -eq 10 ]; then
+            echo "FAILED"
+            fail
+        fi
+
+        sleep 1
+
+        echo -n "$i.. "
+    done
+
+    # ensure that the IPv6 stack is ready; race conditions are fun!
+    sleep 2
+    echo "OK"
+    rdisc6 $ifname > /tmp/ip6_ra
+    # the 'awk' usage below is to trim whitespace around the value
+    ip6_ra_m=$(grep 'Stateful address' /tmp/ip6_ra | cut -d: -f2- | awk '{$1=$1};1')
+    if [ "$ip6_ra_m" = "Yes" ]; then
+        echo "IPv6 on this network is provided by DHCPv6, but this installer does not support DHCPv6."
+        echo "IPv6 will be disabled."
+        ip6_addr=disable
+    fi
+    # the 'awk' usage below is to trim whitespace around the value
+    ip6_ra_o=$(grep 'Stateful other' /tmp/ip6_ra | cut -d: -f2- | awk '{$1=$1};1')
+    if [ "$ip6_ra_o" = "Yes" ]; then
+        echo "IPv6 DNS and other information on this network is provided by DHCPv6, but this installer does not support DHCPv6."
+        echo "IPv6 will be disabled."
+        ip6_addr=disable
+    fi
+fi
+
+if [ "$ip6_addr" = "disable" ]; then
+    # nothing to do, just pass
+    :
+elif [ "$ip6_addr" = "auto" ]; then
+    echo -n "Configuring $ifname for IPv6 using SLAAC... "
+
+    for i in $(seq 1 10); do
+        ip -6 addr ls $ifname | grep -q 'scope global'
+        if [ $? -eq 0 ]; then
+            have_ip6=$(ip -6 addr ls $ifname | grep 'scope global' | awk '{print $2}')
+            echo $have_ip6
+            break
+        fi
+
+        if [ $i -eq 10 ]; then
+            echo "FAILED"
+        fi
+
+        sleep 1
+
+        echo -n "$i.. "
+    done
+else
+    echo -n "Configuring $ifname for IPv6 using static $ip6_addr... "
+    ip addr add $ip6_addr/$ip6_prefixlength dev $ifname || fail
+    if [ "$ip6_gateway" != "auto" ]; then
+        ip route add default via $ip6_gateway || fail
+    fi
+    have_ip6=$ip6_addr
+    echo "OK"
+fi
+
+if [ -n "$have_ip6" ]; then
+    if [ "$ip6_nameservers" = "auto" ]; then
+        echo -n "Obtaining IPv6 recursive DNS server address(es) via RDNSS... "
+        have_ip6_nameservers=$(grep 'Recursive DNS' /tmp/ip6_ra | cut -d: -f2-)
+        if [ -z "$have_ip6_nameservers" ]; then
+            echo "FAILED"
+        else
+            echo "$have_ip6_nameservers"
+        fi
+    elif [ "$ip6_nameservers" != "disable" ]; then
+        have_ip6_nameservers=$ip6_nameservers
+    fi
+    if [ -n "$have_ip6_nameservers" ]; then
+        for i in $have_ip6_nameservers; do
+            echo "nameserver $i" >> /etc/resolv.conf
+        done
+    fi
+    echo "OK"
+fi
+
+if [ -z "$have_ip4" ] && [ -z "$have_ip6" ]; then
+   echo "No IPv4 or IPv6 addresses were configured or obtained. Installation cannot continue."
+   fail
 fi
 
 # This will record the time to get to this point
@@ -491,7 +654,10 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
       base_packages="$base_packages,rng-tools"
     fi
     # minimal
-    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools"
+    minimal_packages="fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools,resolvconf"
+    if [ -n "$have_ip6" ] && [ "$ip6_nameservers" = "auto" ]; then
+        minimal_packages="${minimal_packages},rdnssd"
+    fi
 
     # server
     server_packages="vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,less,man-db"
@@ -515,7 +681,7 @@ if [ "$cdebootstrap_cmdline" = "" ]; then
 
     dhcp_client_package="isc-dhcp-client"
     # add IPv4 DHCP client if needed
-    if [ "$ip_addr" = "dhcp" ]; then
+    if [ "$ip4_addr" = "dhcp" ]; then
         cdebootstrap_cmdline="${cdebootstrap_cmdline},${dhcp_client_package}"
     fi
 
@@ -848,26 +1014,62 @@ echo $hostname > /rootfs/etc/hostname || fail
 echo "OK"
 
 echo -n "  Configuring hosts... "
-touch /rootfs/etc/hosts
-# Add localhost to hosts (if needed)
+rm /rootfs/etc/hosts
+# Add localhost to hosts
 if ! grep -q "localhost" /rootfs/etc/hosts; then
     echo -n "adding localhost... "
     echo "127.0.0.1 localhost" >> /rootfs/etc/hosts || fail
+    if [ -n "$have_ip6" ]; then
+        echo "::1 localhost" >> /rootfs/etc/hosts || fail
+    fi
 fi
 # Remove any existing 127.0.1.1 entries
 sed -i 's/^.*127\.0\.1\.1.*$//' /rootfs/etc/hosts
-# Create the 127.0.1.1 entry
-if [ "$domainname" = "" ]; then
-    echo -n "adding ${hostname}... "
-    echo "127.0.1.1 ${hostname}" >> /rootfs/etc/hosts || fail
-else
-    echo -n "adding ${hostname}.${domainname}... "
-    echo "127.0.1.1 ${hostname}.${domainname} ${hostname}" >> /rootfs/etc/hosts || fail
+
+# Create appropriate hostname entries for IPv4
+if [ -n "$have_ip4" ]; then
+    if [ "$ip4_addr" = "dhcp" ]; then
+        hostfile_addr=127.0.1.1
+    else
+        hostfile_addr=$ip4_addr
+    fi
+    if [ "$domainname" = "" ]; then
+        echo -n "adding ${hostname} for IPv4... "
+        echo "${hostfile_addr} ${hostname}" >> /rootfs/etc/hosts || fail
+    else
+        echo -n "adding ${hostname}.${domainname} for IPv4... "
+        echo "${hostfile_addr} ${hostname}.${domainname} ${hostname}" >> /rootfs/etc/hosts || fail
+    fi
+fi
+echo "OK"
+
+# Create appropriate hostname entries for IPv6
+if [ -n "$have_ip6" ] && [ "$ip6_addr" != "auto" ]; then
+    if [ "$domainname" = "" ]; then
+        echo -n "adding ${hostname} for IPv6... "
+        echo "${ip6_addr} ${hostname}" >> /rootfs/etc/hosts || fail
+    else
+        echo -n "adding ${hostname}.${domainname} for IPv6... "
+        echo "${ip6_addr} ${hostname}.${domainname} ${hostname}" >> /rootfs/etc/hosts || fail
+    fi
 fi
 echo "OK"
 
 # networking
 echo -n "  Configuring network settings... "
+
+if [ "$ip4_addr" = "disable" ]; then
+    # if IPv4 is disabled, configure the DNS resolver in glibc
+    # to prefer IPv6 addresses (by performing AAAA lookups
+    # before A lookups); since resolvconf is installed, this is
+    # done by adding the proper line to the resolvconf 'head'
+    echo "options inet6" >> /etc/resolvconf/resolv.conf.d/head
+fi
+
+if [ "$ip6_addr" = "disable" ]; then
+    echo net.ipv6.conf.all.disable_ipv6=1 > /rootfs/etc/sysctl.d/disable_ipv6.conf
+fi
+
 touch /rootfs/etc/network/interfaces || fail
 # lo interface may already be there, so first check for it
 if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
@@ -879,14 +1081,34 @@ fi
 echo "" >> /rootfs/etc/network/interfaces
 echo "auto $ifname" >> /rootfs/etc/network/interfaces
 echo "allow-hotplug $ifname" >> /rootfs/etc/network/interfaces
-if [ "$ip_addr" = "dhcp" ]; then
+
+if [ "$ip4_addr" = "disable" ]; then
+    # nothing to do, just pass
+    :
+elif [ "$ip4_addr" = "dhcp" ]; then
     echo "iface $ifname inet dhcp" >> /rootfs/etc/network/interfaces
 else
     echo "iface $ifname inet static" >> /rootfs/etc/network/interfaces
-    echo "    address $ip_addr" >> /rootfs/etc/network/interfaces
-    echo "    netmask $ip_netmask" >> /rootfs/etc/network/interfaces
-    echo "    broadcast $ip_broadcast" >> /rootfs/etc/network/interfaces
-    echo "    gateway $ip_gateway" >> /rootfs/etc/network/interfaces
+    echo "    address $ip4_addr/$ip4_prefixlength" >> /rootfs/etc/network/interfaces
+    echo "    gateway $ip4_gateway" >> /rootfs/etc/network/interfaces
+    echo "    dns-nameservers $ip4_nameservers" >> /rootfs/etc/network/interfaces
+fi
+
+if [ "$ip6_addr" = "disable" ]; then
+    # nothing to do, just pass
+    :
+elif [ "$ip6_addr" = "auto" ]; then
+    echo "iface $ifname inet6 auto" >> /rootfs/etc/network/interfaces
+else
+    echo "iface $ifname inet6 static" >> /rootfs/etc/network/interfaces
+    echo "    address $ip6_addr/$ip6_prefixlength" >> /rootfs/etc/network/interfaces
+    if [ "$ip6_gateway" != "auto" ]; then
+        echo "    gateway $ip6_gateway" >> /rootfs/etc/network/interfaces
+        echo "    accept_ra 0" >> /rootfs/etc/network/interfaces
+    fi
+    if [ "$ip6_nameservers" != "auto" ] && [ "$ip6_nameservers" != "disable" ]; then
+        echo "    dns-nameservers $ip6_nameservers" >> /rootfs/etc/network/interfaces
+    fi
 fi
 
 # wlan config
@@ -896,10 +1118,6 @@ if [ "$ifname" != "eth0" ]; then
         cp /bootfs/config/wpa_supplicant.conf /rootfs/etc/wpa_supplicant/
         echo "    wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"	>> /rootfs/etc/network/interfaces
     fi
-    echo "" >> /rootfs/etc/network/interfaces
-    echo "auto eth0" >> /rootfs/etc/network/interfaces
-    echo "allow-hotplug eth0" >> /rootfs/etc/network/interfaces
-    echo "iface eth0 inet dhcp" >> /rootfs/etc/network/interfaces
 fi
 
 if [ "${disable_predictable_nin}" = "1" ]; then
@@ -907,10 +1125,6 @@ if [ "${disable_predictable_nin}" = "1" ]; then
     # adding net.ifnames=0 to /boot/cmdline and disabling the persistent-net-generator.rules
     cmdline="${cmdline} net.ifnames=0"
     ln -s /dev/null /rootfs/etc/udev/rules.d/75-persistent-net-generator.rules
-fi
-
-if [ "$ip_addr" != "dhcp" ]; then
-    cp /etc/resolv.conf /rootfs/etc/ || fail
 fi
 
 echo "OK"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -477,8 +477,8 @@ if [ -n "$have_ip6" ]; then
 fi
 
 if [ -z "$have_ip4" ] && [ -z "$have_ip6" ]; then
-   echo "No IPv4 or IPv6 addresses were configured or obtained. Installation cannot continue."
-   fail
+    echo "No IPv4 or IPv6 addresses were configured or obtained. Installation cannot continue."
+    fail
 fi
 
 # This will record the time to get to this point

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1016,15 +1016,11 @@ echo "OK"
 echo -n "  Configuring hosts... "
 rm /rootfs/etc/hosts
 # Add localhost to hosts
-if ! grep -q "localhost" /rootfs/etc/hosts; then
-    echo -n "adding localhost... "
-    echo "127.0.0.1 localhost" >> /rootfs/etc/hosts || fail
-    if [ -n "$have_ip6" ]; then
-        echo "::1 localhost" >> /rootfs/etc/hosts || fail
-    fi
+echo -n "adding localhost... "
+echo "127.0.0.1 localhost" >> /rootfs/etc/hosts || fail
+if [ -n "$have_ip6" ]; then
+    echo "::1 localhost" >> /rootfs/etc/hosts || fail
 fi
-# Remove any existing 127.0.1.1 entries
-sed -i 's/^.*127\.0\.1\.1.*$//' /rootfs/etc/hosts
 
 # Create appropriate hostname entries for IPv4
 if [ -n "$have_ip4" ]; then

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1123,6 +1123,10 @@ if [ "${disable_predictable_nin}" = "1" ]; then
     ln -s /dev/null /rootfs/etc/udev/rules.d/75-persistent-net-generator.rules
 fi
 
+# copy resolver configuration into rootfs, to be used for remainder of installation
+# will be overwritten by resolvconf when the system is rebooted
+cp /etc/resolv.conf /rootfs/run/resolvconf
+
 echo "OK"
 
 # enable serial console on installed system

--- a/update.sh
+++ b/update.sh
@@ -41,6 +41,7 @@ packages+=("rng-tools")
 packages+=("tar")
 packages+=("util-linux")
 packages+=("wpasupplicant")
+packages+=("ndisc6")
 
 # libraries
 packages+=("libacl1")


### PR DESCRIPTION
This patch adds substantial support for use of IPv6 in the installer,
and in the installed system. It supports static configuration, although
most IPv6 networks use automatic (and dynamic) configuration. This
patch does not provide DHCPv6 support as there is no suitable DHCPv6
client available to use in the installer's environment, but it does
provide support for Router Advertisements, SLAAC, and RDNSS.

In order to simplify management of DNS resolver information in the
installed system (since there are multiple potential sources of this
information), this patch adds the 'resolvconf' package to the installed
system. If IPv6 DNS information is gathered from RDNSS, the 'rdnssd'
package will also be added to the installed system.

For discovery of Router Advertisment-provided information during the
installation, the patch also adds tools from the 'ndisc6' package to
the installer.

Finally, to provide consistent syntax in the installer configuration
file, this patch changes the 'ip_*' options to use an 'ip4_' prefix
instead, and also uses 'prefix length' instead of 'netmask' for
IPv4 networks. It supports prior configuration files, though, and
will automatically convert options in the old format.
