### PR TITLE
change special character in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Release v1.0.8 (2015-12-01)
+
+The following changes are part of this release:
+- Changed default release from wheezy to jessie.
+- Changed the retrieval of date/time from rdate to ntpdate.
+- Moved setting of `/tmp` to `/etc/fstab` so it works across init systems.
+- Make sure kernel gets installed on all preset values. This fixes [issue 253](https://github.com/debian-pi/raspbian-ua-netinst/issues/253), [issue 277](https://github.com/debian-pi/raspbian-ua-netinst/issues/277) and [issue 279](https://github.com/debian-pi/raspbian-ua-netinst/issues/279).
+- Improved the checks on the archive keys and extracted the code for it into separate functions.
+- Added gzip compression to the cpio files to reduce the size of the installer.
+- Changed setting of various filesystem parameter to be after loading of `online_config` so it can be set from there.
+- Various improvements to the build process.
+- Various improvements to the documentation.
+
+See the [README](https://github.com/debian-pi/raspbian-ua-netinst/blob/v1.0.8/README.md) for features/installation instruction/etc for this release.
+
+
 # Release v1.0.7 (2015-05-05)
 
 Below are the changes since the 1.0.6 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Release v1.0.9 (2016-09-18)
+
+The following changes are part of this release:
+- Updated kernel and firmware to support new Raspberry Pi 1B+ revision. This fixes [issue 415](https://github.com/debian-pi/raspbian-ua-netinst/issues/415).
+- Improved various documentation parts. This fixes [issue 407](https://github.com/debian-pi/raspbian-ua-netinst/issues/407).
+- Improved the way `/etc/hostname` and `/etc/network/interfaces` are written to make it more resilient.
+
+See the [README](https://github.com/debian-pi/raspbian-ua-netinst/blob/v1.0.9/README.md) for features/installation instruction/etc for this release.
+
+
 # Release v1.0.8.1 (2015-12-24)
 
 The following changes are part of this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Release v1.0.8.1 (2015-12-24)
+
+The following changes are part of this release:
+- Added check for existence of file before operating on it.
+- Fixed wrong command when setting security on swap file in documentation. This fixes [issue 327](https://github.com/debian-pi/raspbian-ua-netinst/issues/327) and fixes [issue 343](https://github.com/debian-pi/raspbian-ua-netinst/issues/343).
+- Added info to documentation to make clear that `ntpdate` is used primarily and `rdate` only as fallback.
+
+See the [README](https://github.com/debian-pi/raspbian-ua-netinst/blob/v1.0.8.1/README.md) for features/installation instruction/etc for this release.
+
+
 # Release v1.0.8 (2015-12-01)
 
 The following changes are part of this release:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ So don't copy and paste the defaults from below!
 
 The _installer-config.txt_ is read in at the beginning of the installation process, shortly followed by the file pointed to with `online_config`, if specified.
 There is also another configuration file you can provide, _post&#8209;install.txt_, and you place that in the same directory as _installer-config.txt_.
-The _post&#8209;install.txt_ is executed at the very end of the installation process and you can use it to tweak and finalize your automatic installation.  
+The _post-install.txt_ is executed at the very end of the installation process and you can use it to tweak and finalize your automatic installation.  
 The configuration files are read in as  shell scripts, so you can abuse that fact if you so want to.
 
 The format of the _installer-config.txt_ file and the current defaults:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When you need a kernel module that isn't loaded by default, you will still have 
 > Optional: `apt-get install rng-tools` and add `bcm2708-rng` to `/etc/modules` to auto-load and use the kernel module for the hardware random number generator. This improves the performance of various server applications needing random numbers significantly.
 
 ## Reinstalling or replacing an existing system
-If you want to reinstall with the same settings you did your first install you can just move the original _config.txt_ back and reboot. Make sure you still have _kernel_install.img_ and _installer.cpio.gz_ in your _/boot_ partition. If you are replacing your existing system which was not installed using this method, make sure you copy those two files in and the installer _config.txt_ from the original image.
+If you want to reinstall with the same settings you did your first install you can just move the original _config.txt_ back and reboot. Depending on the hardware you want to reinstall on (Raspberry Pi **1**, **2** or **3**), make sure you still have _kernel_rpi1_install.img_ (for RPI1) / _kernel_rpi2_install.img_ (for RPi2/3) and _installer-rpi1.cpio.gz_ (for RPi1) / _installer-rpi2.cpio.gz_ (for RPi2/3) in your _/boot_ partition. If you are replacing your existing system which was not installed using this method, make sure you copy those files in and the installer _config.txt_ from the original image.
 
     mv /boot/config-reinstall.txt /boot/config.txt
     reboot
@@ -169,7 +169,7 @@ If you want to reinstall with the same settings you did your first install you c
 **Remember to backup all your data and original config.txt before doing this!**
 
 ## Reporting bugs and improving the installer
-When you encounter issues, have wishes or have code or documentation improvements, we'd like to hear from you! 
+When you encounter issues, have wishes or have code or documentation improvements, we'd like to hear from you!
 We've actually written a document on how to best do this and you can find it [here](CONTRIBUTING.md).
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ Other presets include _minimal_ which has even less packages (no logging, no tex
  - always installs the latest version of Raspbian
  - configurable default settings
  - extra configuration over HTTP possible - gives unlimited flexibility
- - installation takes about **15 minutes** with fast Internet from power on to sshd running
  - can fit on 512MB SD card, but 1GB is more reasonable
- - default install includes fake-hwclock to save time on shutdown
- - default install includes NTP to keep time
+ - default install includes fake-hwclock to save the current date and time on shutdown
+ - default install includes NTP to keep the time up-to-date if a network connection is available.
  - /tmp is mounted as tmpfs to improve speed
  - no clutter included, you only get the bare essential packages
  - option to install root to USB drive

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ and that's it! While most settings stand on their own, some settings influence e
 So don't copy and paste the defaults from below!
 
 The _installer-config.txt_ is read in at the beginning of the installation process, shortly followed by the file pointed to with `online_config`, if specified.
-There is also another configuration file you can provide, _post&#8209;install.txt_, and you place that in the same directory as _installer-config.txt_.
+There is also another configuration file you can provide, _post-install.txt_, and you place that in the same directory as _installer-config.txt_.
 The _post-install.txt_ is executed at the very end of the installation process and you can use it to tweak and finalize your automatic installation.  
 The configuration files are read in as  shell scripts, so you can abuse that fact if you so want to.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The format of the _installer-config.txt_ file and the current defaults:
     rootfs_install_mount_options='noatime,data=writeback,nobarrier,noinit_itable'
     rootfs_mount_options='errors=remount-ro,noatime'
 
-The time server is only used during installation and is for _rdate_ which doesn't support the NTP protocol.  
+The timeserver parameter is only used during installation for _rdate_ which is used as fallback when setting the time with `ntpdate` fails.  
 
 Available presets: _server_, _minimal_ and _base_.
 Presets set the `cdebootstrap_cmdline` variable. For example, the current _server_ default is:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Format your SD card as **FAT32** (MS-DOS on _Mac OS X_) and extract the installe
 Try formatting the SD card with this tool: https://www.sdcard.org/downloads/formatter_4/
 
 ### Alternative method for Mac, writing image to SD card
-Prebuilt image is around **20MB** bzip2 compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Mac users.
+Prebuilt image is around **19MB** bzip2 compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Mac users.
 
 Go to [our latest release page](https://github.com/debian-pi/raspbian-ua-netinst/releases/latest) and download the .img.bz2 file.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Other presets include _minimal_ which has even less packages (no logging, no tex
 
 ## Writing the installer to the SD card
 ### Obtaining installer files on Windows and Mac
-Installer archive is around **19MB** and contains all firmware files and the installer.
+Installer archive is around **24MB** and contains all firmware files and the installer.
 
 Go to [our latest release page](https://github.com/debian-pi/raspbian-ua-netinst/releases/latest) and download the .zip file.
 
@@ -53,7 +53,7 @@ Format your SD card as **FAT32** (MS-DOS on _Mac OS X_) and extract the installe
 Try formatting the SD card with this tool: https://www.sdcard.org/downloads/formatter_4/
 
 ### Alternative method for Mac, writing image to SD card
-Prebuilt image is around **19MB** bzip2 compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Mac users.
+Prebuilt image is around **24MB** bzip2 compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Mac users.
 
 Go to [our latest release page](https://github.com/debian-pi/raspbian-ua-netinst/releases/latest) and download the .img.bz2 file.
 
@@ -69,7 +69,7 @@ To flash your SD card on Mac:
 _Note the **r** in the of=/dev/rdiskX part on the dd line which should speed up writing the image considerably._
 
 ### SD card image for Linux
-Prebuilt image is around **17MB** xz compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Linux users.
+Prebuilt image is around **20MB** xz compressed and **64MB** uncompressed. It contains the same files as the .zip but is more convenient for Linux users.
 
 Go to [our latest release page](https://github.com/debian-pi/raspbian-ua-netinst/releases/latest) and download the .img.xz file.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The latest kernel and firmware packages are now automatically installed during t
 When you need a kernel module that isn't loaded by default, you will still have to configure that manually.
 
 > Optional: `apt-get install raspi-copies-and-fills` for improved memory management performance.  
-> Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap && chown og-r /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.  
+> Optional: Create a swap file with `dd if=/dev/zero of=/swap bs=1M count=512 && mkswap /swap && chmod 600 /swap` (example is 512MB) and enable it on boot by appending `/swap none swap sw 0 0` to `/etc/fstab`.  
 > Optional: `apt-get install rng-tools` and add `bcm2708-rng` to `/etc/modules` to auto-load and use the kernel module for the hardware random number generator. This improves the performance of various server applications needing random numbers significantly.
 
 ## Reinstalling or replacing an existing system

--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,11 @@
 
 set -e
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
-INSTALL_MODULES="kernel/fs/f2fs/f2fs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/fs/btrfs/btrfs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/usb/storage/usb-storage.ko"
+INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sd_mod.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -528,7 +528,13 @@ echo "OK"
 # default hostname
 echo -n "  Configuring hostname... "
 echo -n $hostname > /rootfs/etc/hostname || fail
-echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
+if [ ! -f /rootfs/etc/hosts ]; then
+    echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
+else
+    if ! grep -q "localhost" /rootfs/etc/hosts; then
+        echo "127.0.0.1	localhost" >> /rootfs/etc/hosts
+    fi
+fi
 if [ "$domainname" = "" ]; then
      echo "127.0.1.1	$hostname" >> /rootfs/etc/hosts || fail
 else
@@ -537,10 +543,13 @@ fi
 echo "OK"
 
 # networking
+# wheezy seems to add the lo interface, so first check for it
 echo -n "  Configuring network settings... "
-echo "auto lo" > /rootfs/etc/network/interfaces || fail
-echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces || fail
-echo "" >>  /rootfs/etc/network/interfaces || fail
+if ! grep -q "auto lo" /rootfs/etc/network/interfaces; then
+    echo "auto lo" > /rootfs/etc/network/interfaces || fail
+    echo "iface lo inet loopback" >> /rootfs/etc/network/interfaces || fail
+    echo "" >>  /rootfs/etc/network/interfaces || fail
+fi
 
 # eth0 config
 echo "auto eth0" >> /rootfs/etc/network/interfaces || fail

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -527,7 +527,7 @@ echo "OK"
 
 # default hostname
 echo -n "  Configuring hostname... "
-echo -n $hostname > /rootfs/etc/hostname || fail
+echo $hostname > /rootfs/etc/hostname || fail
 if [ ! -f /rootfs/etc/hosts ]; then
     echo "127.0.0.1	localhost" > /rootfs/etc/hosts || fail
 else

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -565,7 +565,7 @@ echo "OK"
 
 # openssh-server in jessie doesn't allow root to login using password anymore
 # this hack does allow it (until a proper solution is implemented)
-if [ "$release" = "jessie" ] ; then
+if [ "$release" = "jessie" ] && [ -f /rootfs/etc/ssh/sshd_config ] ; then
     echo -n "  Allowing root to login with password... "
     sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /rootfs/etc/ssh/sshd_config || fail
     echo "OK"

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-KERNEL_VERSION_RPI1=3.18.0-trunk-rpi
-KERNEL_VERSION_RPI2=3.18.0-trunk-rpi2
+KERNEL_VERSION_RPI1=4.4.0-1-rpi
+KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
 RASPBIAN_ARCHIVE_KEY_DIRECTORY="https://archive.raspbian.org"
 RASPBIAN_ARCHIVE_KEY_FILE_NAME="raspbian.public.key"


### PR DESCRIPTION
When copy-and-paste the filename `post‑install.txt` you get an error while installing, because the hyphen was written as a special character.

```
Copying /boot files in... cp: can't create '/boot/post?install.txt': Invalid argument
```