### PR TITLE
Added firmware and modules for the wlan on RPi3 and ZeroW

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,14 @@
 
 set -e
 
+# configuration
 KERNEL_VERSION_RPI1=4.4.0-1-rpi
 KERNEL_VERSION_RPI2=4.4.0-1-rpi2
 
-INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
-INSTALL_MODULES="$INSTALL_MODULES kernel/net/ipv6/ipv6.ko"
+INSTALL_MODULES=("kernel/fs/btrfs/btrfs.ko")
+INSTALL_MODULES+=("kernel/drivers/scsi/sg.ko")
+INSTALL_MODULES+=("kernel/net/ipv6/ipv6.ko")
+INSTALL_MODULES+=("kernel/net/wireless/cfg80211.ko")
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found
@@ -119,7 +121,7 @@ function create_cpio {
     depmod_file=$(create_tempfile)
     /sbin/depmod -nab tmp ${KERNEL_VERSION} > ${depmod_file}
 
-    modules=(${INSTALL_MODULES})
+    modules=("${INSTALL_MODULES[@]}")
 
     # new_count contains the number of new elements in the $modules array for each iteration
     new_count=${#modules[@]}
@@ -151,6 +153,9 @@ function create_cpio {
     sed -i "s/__VERSION__/git~`git rev-parse --short @{0}`/" rootfs/etc/init.d/rcS
     sed -i "s/__DATE__/`date`/" rootfs/etc/init.d/rcS
 
+    # add firmware for wireless chipset (RPi 3 and Zero W)
+    mkdir -p rootfs/lib/firmware/brcm
+    cp tmp/lib/firmware/brcm/brcmfmac43430-sdio.{bin,txt} rootfs/lib/firmware/brcm
 
     # btrfs-tools components
     cp tmp/sbin/mkfs.btrfs rootfs/sbin/

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1273,6 +1273,17 @@ if [ "$kernel_module" = true ] ; then
   fi
 fi
 
+# install firmware for wireless chipset (RPi 3 and Zero W)
+if [ "$ifname" != "eth0" ]; then
+  echo -n "Installing firmware for Broadcom wireless network cards... "
+  chroot /rootfs /usr/bin/apt-get -y install firmware-brcm80211 &>/dev/null
+  if [ $? -eq 0 ]; then
+    echo "OK"
+  else
+    echo "FAILED !"
+  fi
+fi
+
 # install libraspberrypi-bin to provide vcgencmd functionality
 echo -n "Installing libraspberrypi-bin package (=vcgencmd,raspistill,raspivid,etc)... "
 chroot /rootfs /usr/bin/apt-get -y install libraspberrypi-bin &>/dev/null

--- a/update.sh
+++ b/update.sh
@@ -13,10 +13,8 @@ RASPBERRYPI_ARCHIVE_KEY_FILE_NAME="raspberrypi.gpg.key"
 RASPBERRYPI_ARCHIVE_KEY_URL="${RASPBERRYPI_ARCHIVE_KEY_DIRECTORY}/${RASPBERRYPI_ARCHIVE_KEY_FILE_NAME}"
 RASPBERRYPI_ARCHIVE_KEY_FINGERPRINT="CF8A1AF502A2AA2D763BAE7E82B129927FA3303E"
 
-FIRMWARE_PACKAGE=${RASPBERRYPI_ARCHIVE_KEY_DIRECTORY}/pool/main/f/firmware-nonfree/firmware-brcm80211_0.43+rpi5_all.deb
-FIRMWARE_SHA256=a8c247ba7b39b265c3fb2042bc376cb1df08323608b2b442d4bea130782f4d7c
-
-mirror=http://archive.raspbian.org/raspbian/
+mirror_raspbian="http://archive.raspbian.org/raspbian"
+mirror_raspberrypi="http://archive.raspberrypi.org/debian"
 release=jessie
 
 packages=()
@@ -25,6 +23,7 @@ packages=()
 packages+=("raspberrypi-bootloader-nokernel")
 packages+=("linux-image-${KERNEL_VERSION_RPI1}")
 packages+=("linux-image-${KERNEL_VERSION_RPI2}")
+packages+=("firmware-brcm80211")
 packages+=("btrfs-tools")
 packages+=("busybox")
 packages+=("cdebootstrap-static")
@@ -78,17 +77,30 @@ packages+=("libtinfo5")
 packages+=("libuuid1")
 packages+=("zlib1g")
 
+download_file() {
+    local source="$1"
+    local target="$2"
+    local options=(-q --show-progress --no-cache)
+    if [ -n "${target}" ] ; then
+        options+=(-O "${target}")
+    fi
+    if ! wget "${options[@]}" "${source}" ; then
+        echo -e "ERROR\nDownloading file '${source}' failed! Exiting."
+        exit 1
+    fi
+}
+
 check_key() {
     # param 1 = keyfile
     # param 2 = key fingerprint
 
     # check input parameters
-    if [ -z $1 ] || [ ! -f $1 ] ; then
+    if [ -z "$1" ] || [ ! -f "$1" ] ; then
         echo "Parameter 1 of check_key() is not a file!"
         return 1
     fi
 
-    if [ -z $2 ] ; then
+    if [ -z "$2" ] ; then
         echo "Parameter 2 of check_key() is not a key fingerprint!"
         return 1
     fi
@@ -99,14 +111,14 @@ check_key() {
     echo -n "Checking key file '${KEY_FILE}'... "
 
     # check that there is only 1 public key in the key file
-    if [ ! $(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons ${KEY_FILE} | grep ^pub: | wc -l) -eq 1 ] ; then
+    if [ "$(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons "${KEY_FILE}" | grep ^pub: | wc -l)" -ne 1 ] ; then
         echo "FAILED!"
         echo "There are zero or more than one keys in the ${KEY_FILE} key file!"
         return 1
     fi
 
     # check that the key file's fingerprint is correct
-    if [ "$(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons ${KEY_FILE} | grep ^fpr: | awk -F: '{print $10}')" != "${KEY_FINGERPRINT}" ] ; then
+    if [ "$(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons "${KEY_FILE}" | grep ^fpr: | awk -F: '{print $10}')" != "${KEY_FINGERPRINT}" ] ; then
         echo "FAILED!"
         echo "Bad GPG key fingerprint for ${KEY_FILE}!"
         return 1
@@ -117,7 +129,6 @@ check_key() {
 }
 
 setup_archive_keys() {
-
     mkdir -m 0700 -p gnupg
     # Let gpg set itself up already in the 'gnupg' dir before we actually use it
     echo "Setting up gpg... "
@@ -125,7 +136,7 @@ setup_archive_keys() {
     echo ""
 
     echo "Downloading ${RASPBIAN_ARCHIVE_KEY_FILE_NAME}."
-    curl -# -O ${RASPBIAN_ARCHIVE_KEY_URL}
+    download_file "${RASPBIAN_ARCHIVE_KEY_URL}"
     if check_key "${RASPBIAN_ARCHIVE_KEY_FILE_NAME}" "${RASPBIAN_ARCHIVE_KEY_FINGERPRINT}" ; then
         # GPG key checks out, thus import it into our own keyring
         echo -n "Importing '${RASPBIAN_ARCHIVE_KEY_FILE_NAME}' into keyring... "
@@ -142,7 +153,7 @@ setup_archive_keys() {
     echo ""
 
     echo "Downloading ${RASPBERRYPI_ARCHIVE_KEY_FILE_NAME}."
-    curl -# -O ${RASPBERRYPI_ARCHIVE_KEY_URL}
+    download_file "${RASPBERRYPI_ARCHIVE_KEY_URL}"
     if check_key "${RASPBERRYPI_ARCHIVE_KEY_FILE_NAME}" "${RASPBERRYPI_ARCHIVE_KEY_FINGERPRINT}" ; then
         # GPG key checks out, thus import it into our own keyring
         echo -n "Importing '${RASPBERRYPI_ARCHIVE_KEY_FILE_NAME}' into keyring..."
@@ -157,7 +168,6 @@ setup_archive_keys() {
     fi
 
     return 0
-
 }
 
 required() {
@@ -186,58 +196,60 @@ filter_package_list() {
 download_package_list() {
     # Download and verify package list for $package_section, then add to Packages file
     # Assume that the repository's base Release file is present
+    local source="$1"
+    local base_url="$2"
 
     extensions=( '.xz' '.bz2' '.gz' '' )
     for extension in "${extensions[@]}" ; do
 
         # Check that this extension is available
-        if grep -q ${package_section}/binary-armhf/Packages${extension} Release ; then
+        if grep -q "${package_section}/binary-armhf/Packages${extension}" "${source}_Release" ; then
 
             # Download Packages file
             echo -e "\nDownloading ${package_section} package list..."
-            curl -# -o tmp${extension} $mirror/dists/$release/$package_section/binary-armhf/Packages${extension}
+            if ! download_file "${base_url}/dists/${release}/${package_section}/binary-armhf/Packages${extension}" "Packages${extension}" ; then
+                echo -e "ERROR\nDownloading '${package_section}' package list failed! Exiting."
+                cd ..
+                exit 1
+            fi
 
             # Verify the checksum of the Packages file, assuming that the last checksums in the Release file are SHA256 sums
             echo -n "Verifying ${package_section} package list... "
-            if [ $(grep ${package_section}/binary-armhf/Packages${extension} Release | tail -n1 | awk '{print $1}') = \
-                 $(sha256sum tmp${extension} | awk '{print $1}') ]; then
+            if [ "$(grep "${package_section}/binary-armhf/Packages${extension}" "${source}_Release" | tail -n1 | awk '{print $1}')" = \
+                "$(sha256sum "Packages${extension}" | awk '{print $1}')" ] ; then
                 echo "OK"
             else
-                echo -e "ERROR\nThe checksum of the ${package_section}/binary-armhf/Packages${extension} file doesn't match!"
+                echo -e "ERROR\nThe checksum of file '${package_section}/binary-armhf/Packages${extension}' doesn't match!"
                 cd ..
                 exit 1
             fi
 
             # Decompress the Packages file
-            if [ $extension = ".bz2" ] ; then
+            if [ "${extension}" = ".bz2" ] ; then
                 decompressor="bunzip2 -c "
-            elif [ $extension = ".xz" ] ; then
+            elif [ "${extension}" = ".xz" ] ; then
                 decompressor="xzcat "
-            elif [ $extension = ".gz" ] ; then
+            elif [ "${extension}" = ".gz" ] ; then
                 decompressor="gunzip -c "
-            elif [ $extension = "" ] ; then
+            elif [ "${extension}" = "" ] ; then
                 decompressor="cat "
             fi
-            ${decompressor} tmp${extension} >> Packages
-            rm tmp${extension}
+            ${decompressor} "Packages${extension}" >> "${source}_Packages"
+            rm "Packages${extension}"
             break
         fi
     done
 }
 
 download_package_lists() {
-
-    setup_archive_keys
-    if [ $? != 0 ] ; then
-        echo -e "ERROR\nSetting up the archives failed! Exiting."
-        cd ..
-        exit 1
-    fi
+    local source="$1"
+    local base_url="$2"
 
     echo -e "\nDownloading Release file and its signature..."
-    curl -# -O $mirror/dists/$release/Release -O $mirror/dists/$release/Release.gpg
+    download_file "${base_url}/dists/$release/Release" "${source}_Release"
+    download_file "${base_url}/dists/$release/Release.gpg" "${source}_Release.gpg"
     echo -n "Verifying Release file... "
-    if gpg --homedir gnupg --verify Release.gpg Release &> /dev/null ; then
+    if gpg --homedir gnupg --verify "${source}_Release.gpg" "${source}_Release" &> /dev/null ; then
         echo "OK"
     else
         echo -e "ERROR\nBroken GPG signature on Release file!"
@@ -245,51 +257,81 @@ download_package_lists() {
         exit 1
     fi
 
-    echo -n > Packages
-    package_section=firmware
-    download_package_list
-    package_section=main
-    download_package_list
-    package_section=non-free
-    download_package_list
+    echo -n > "${source}_Packages"
+
+    for package_section in firmware main non-free; do
+        download_package_list "${source}" "${base_url}"
+    done
 }
 
-rm -rf packages/
-mkdir packages
-cd packages
+search_for_packages() {
+    local source="$1"
+    local base_url="$2"
 
-download_package_lists
+    while read -r k v
+    do
+        if [ "${k}" = "Package:" ] ; then
+            current_package="${v}"
+        elif [ "${k}" = "Filename:" ] ; then
+            current_filename="${v}"
+        elif [ "${k}" = "SHA256:" ] ; then
+            current_sha256="${v}"
+        elif [ "${k}" = "" ] ; then
+            if required "$current_package" ; then
+                printf "  %-32s %s\n" "${current_package}" "$(basename "${current_filename}")"
+                unset_required "${current_package}"
+                packages_debs+=("${base_url}/${current_filename}")
+                packages_sha256+=("${current_sha256} $(basename "${current_filename}")")
+                allfound && break
+            fi
+
+            current_package=
+            current_filename=
+            current_sha256=
+        fi
+    done < <(filter_package_list <"${source}_Packages")
+}
+
+download_packages() {
+    echo -e "\nDownloading packages..."
+    if ! wget -q --show-progress --no-cache -- "${packages_debs[@]}" ; then
+        echo -e "ERROR\nDownloading packages failed! Exiting."
+        cd ..
+        exit 1
+    fi
+    
+    echo -ne "\nVerifying downloaded packages... "
+    printf "%s\n" "${packages_sha256[@]}" > SHA256SUMS
+    if sha256sum --quiet -c SHA256SUMS; then
+        echo "OK"
+    else
+        echo -e "ERROR\nThe checksums of the downloaded packages don't match the package lists!"
+        cd ..
+        exit 1
+    fi
+}
+
+# Setup
+rm -rf packages/
+mkdir packages/ && cd packages
+
+if ! setup_archive_keys ; then
+    echo -e "ERROR\nSetting up the archives failed! Exiting."
+    exit 1
+fi
+
+## Download package list
+download_package_lists raspberry "${mirror_raspberrypi}"
+download_package_lists raspbian "${mirror_raspbian}"
+
+## Select packages for download
+echo -e "\nSearching for required packages..."
 
 packages_debs=()
 packages_sha256=()
 
-# add firmware for wireless chipset (RPi 3 and Zero W)
-packages_debs+=("${FIRMWARE_PACKAGE}")
-packages_sha256+=("${FIRMWARE_SHA256}  $(basename ${FIRMWARE_PACKAGE})")
-
-echo -e "\nSearching for required packages..."
-while read k v
-do
-    if [ "$k" = "Package:" ]; then
-        current_package=$v
-    elif [ "$k" = "Filename:" ]; then
-        current_filename=$v
-    elif [ "$k" = "SHA256:" ]; then
-        current_sha256=$v
-    elif [ "$k" = "" ]; then
-        if required $current_package; then
-            printf "  %-32s %s\n" $current_package $(basename $current_filename)
-            unset_required $current_package
-            packages_debs+=("${mirror}${current_filename}")
-            packages_sha256+=("${current_sha256}  $(basename ${current_filename})")
-            allfound && break
-        fi
-
-        current_package=
-        current_filename=
-        current_sha256=
-    fi
-done < <(filter_package_list <Packages)
+search_for_packages raspberry "${mirror_raspberrypi}"
+search_for_packages raspbian "${mirror_raspbian}"
 
 if ! allfound ; then
     echo "ERROR: Unable to find all required packages in package list!"
@@ -298,17 +340,7 @@ if ! allfound ; then
     exit 1
 fi
 
-echo -e "\nDownloading packages..."
-curl -# --remote-name-all ${packages_debs[@]}
-
-echo -n "Verifying downloaded packages... "
-printf "%s\n" "${packages_sha256[@]}" > SHA256SUMS
-if sha256sum --quiet -c SHA256SUMS ; then
-    echo "OK"
-else
-    echo -e "ERROR\nThe checksums of the downloaded packages don't match the package lists!"
-    cd ..
-    exit 1
-fi
+## Download selected packages
+download_packages
 
 cd ..

--- a/update.sh
+++ b/update.sh
@@ -13,6 +13,9 @@ RASPBERRYPI_ARCHIVE_KEY_FILE_NAME="raspberrypi.gpg.key"
 RASPBERRYPI_ARCHIVE_KEY_URL="${RASPBERRYPI_ARCHIVE_KEY_DIRECTORY}/${RASPBERRYPI_ARCHIVE_KEY_FILE_NAME}"
 RASPBERRYPI_ARCHIVE_KEY_FINGERPRINT="CF8A1AF502A2AA2D763BAE7E82B129927FA3303E"
 
+FIRMWARE_PACKAGE=${RASPBERRYPI_ARCHIVE_KEY_DIRECTORY}/pool/main/f/firmware-nonfree/firmware-brcm80211_0.43+rpi5_all.deb
+FIRMWARE_SHA256=a8c247ba7b39b265c3fb2042bc376cb1df08323608b2b442d4bea130782f4d7c
+
 mirror=http://archive.raspbian.org/raspbian/
 release=jessie
 
@@ -74,10 +77,6 @@ packages+=("libssl1.0.0")
 packages+=("libtinfo5")
 packages+=("libuuid1")
 packages+=("zlib1g")
-
-packages_found=
-packages_debs=
-packages_sha256=
 
 check_key() {
     # param 1 = keyfile
@@ -263,6 +262,10 @@ download_package_lists
 
 packages_debs=()
 packages_sha256=()
+
+# add firmware for wireless chipset (RPi 3 and Zero W)
+packages_debs+=("${FIRMWARE_PACKAGE}")
+packages_sha256+=("${FIRMWARE_SHA256}  $(basename ${FIRMWARE_PACKAGE})")
 
 echo -e "\nSearching for required packages..."
 while read k v


### PR DESCRIPTION
Request for comments: What needs to be changed to get pulled?

I got my hands on a RPi3 and after some tinkering, I got the installation over onboard WLAN to work.
While adding to much firmware to this installer probably wouldn't be a good idea, the Pi 3 and the Zero W seem to have the same chip (brcm43430), and supporting the official Raspberry chipsets would be reasonable.

However, the firmware package in Raspbian is too old, we need the one from raspberrypi.org. If that would be ok, I would add that as second download mirror (like this fork does: https://github.com/FooDeas/raspberrypi-ua-netinst ).