### PR TITLE
Add HWRNG kernel module back and explicitly load the module.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ KERNEL_VERSION_RPI2=4.9.0-2-rpi2
 
 INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
+INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/char/hw_random/bcm2835-rng.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/net/ipv6/ipv6.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -212,6 +212,7 @@ echo "https://github.com/debian-pi/raspbian-ua-netinst/"
 echo "================================================="
 
 echo -n "Starting HWRNG "
+modprobe bcm2835-rng
 /usr/sbin/rngd -r /dev/hwrng
 if [ $? -eq 0 ]; then
     echo "succeeded!"


### PR DESCRIPTION
It was build-in with kernel 4.4, but with 4.9 it is once again build as
a kernel module (like it was before 4.4).