### PR TITLE
Disable UART for the installer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -565,7 +565,8 @@ echo "initramfs installer-rpi2.cpio.gz" >> bootfs/config.txt
 # on the rpi3 the uart port is used by bluetooth by default
 # but during the installation we want the serial console
 # the next statement does that, but consequently also disables bluetooth
-echo "enable_uart=1" >> bootfs/config.txt
+# FIXME: This line leads to a kernel panic with the current firmware/kernel
+##echo "enable_uart=1" >> bootfs/config.txt
 
 # rpi zero uses the same kernel/initramfs as rpi1, so just copy the block
 echo "[pi0]" >> bootfs/config.txt


### PR DESCRIPTION
Avoid kernel panic on boot of RPi3.

With current kernel and firmware, we probably have to enable UART by a device tree overlay.