### PR TITLE
Blacklist rtl8192cu, let mdev use 8192cu instead

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ INSTALL_MODULES="kernel/fs/btrfs/btrfs.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/scsi/sg.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/drivers/char/hw_random/bcm2835-rng.ko"
 INSTALL_MODULES="$INSTALL_MODULES kernel/net/ipv6/ipv6.ko"
+INSTALL_MODULES="$INSTALL_MODULES kernel/net/wireless/cfg80211.ko"
 
 # checks if first parameter is contained in the array passed as the second parameter
 #   use: contains_element "search_for" "${some_array[@]}" || do_if_not_found

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -1131,6 +1131,9 @@ fi
 # will be overwritten by resolvconf when the system is rebooted
 cp /etc/resolv.conf /rootfs/run/resolvconf
 
+# copy blacklist for rtl8192cu into rootfs; use original Realtek drivers instead
+cp /etc/modprobe.d/blacklist-native-rtl8192.conf /rootfs/etc/modprobe.d/
+
 echo "OK"
 
 # enable serial console on installed system

--- a/scripts/etc/modprobe.d/blacklist-native-rtl8192.conf
+++ b/scripts/etc/modprobe.d/blacklist-native-rtl8192.conf
@@ -1,0 +1,1 @@
+blacklist rtl8192cu


### PR DESCRIPTION
* Blacklisting kernel module rtl8192cu, as it does not work properly and binds to the wireless device, preventing from loading 8192cu.
* Adding cfg80211.ko to the initramfs, as it is needed for the driver 8192cu with the current kernel (also needed for RPi3 onboard WLAN, see #470)