### PR TITLE
Identify Pi Zero W etc.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -184,17 +184,20 @@ case $cpu_revision in
     0011|0014)
         rpi_hardware_version="cm"
         ;;
-    900092|900093)
+    900092|900093|920093|9000c1)
         rpi_hardware_version="0"
         ;;
-    0002|0003|0004|0005|0006|0007|0008|0009|000d|000e|000f|0010|0012|0013|0015|900032)
+    0002|0003|0004|0005|0006|0007|0008|0009|000d|000e|000f|0010|0012|0013|0015|900021|900032)
         rpi_hardware_version="1"
         ;;
-    a01041|a21041|a22042)
+    A01040|a01041|a21041|a22042)
         rpi_hardware_version="2"
         ;;
-    a02082|a22082)
+    a02082|a22082|a32082)
         rpi_hardware_version="3"
+        ;;
+    a020a0)
+        rpi_hardware_version="cm3"
         ;;
     *)
         rpi_hardware_version="unknown"
@@ -568,7 +571,7 @@ if [ "$hardware_versions" = "detect" ]; then
            echo "================================================="
            echo "     No Raspberry Pi hardware detected!!"
            echo " Value of cpu_revision variable: '${cpu_revision}'"
-           echo "          Building for Pi 1, 2 and 3.         "
+           echo "        Building for Pi 0. 1, 2 and 3.        "
            echo "================================================="
            echo ""
            hardware_versions="1 2 3"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -571,7 +571,7 @@ if [ "$hardware_versions" = "detect" ]; then
            echo "================================================="
            echo "     No Raspberry Pi hardware detected!!"
            echo " Value of cpu_revision variable: '${cpu_revision}'"
-           echo "        Building for Pi 0. 1, 2 and 3.        "
+           echo "        Building for Pi 0, 1, 2 and 3."
            echo "================================================="
            echo ""
            hardware_versions="1 2 3"

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -181,24 +181,24 @@ rm ${LOGFILE}.pipe
 # http://elinux.org/RPi_HardwareHistory#Board_Revision_History
 cpu_revision=$(grep Revision /proc/cpuinfo | cut -d " " -f 2 | sed 's/^1000//')
 case $cpu_revision in
-    0011|0014)
-        rpi_hardware_version="cm"
-        ;;
+#    0011|0014)
+#        rpi_hardware_version="cm"  # not supported
+#       ;;
     900092|900093|920093|9000c1)
         rpi_hardware_version="0"
         ;;
     0002|0003|0004|0005|0006|0007|0008|0009|000d|000e|000f|0010|0012|0013|0015|900021|900032)
         rpi_hardware_version="1"
         ;;
-    A01040|a01041|a21041|a22042)
+    a01040|a01041|a21041|a22042)
         rpi_hardware_version="2"
         ;;
     a02082|a22082|a32082)
         rpi_hardware_version="3"
         ;;
-    a020a0)
-        rpi_hardware_version="cm3"
-        ;;
+#    a020a0)
+#        rpi_hardware_version="cm3"  # not supported
+#        ;;
     *)
         rpi_hardware_version="unknown"
         ;;
@@ -574,7 +574,7 @@ if [ "$hardware_versions" = "detect" ]; then
            echo "        Building for Pi 0, 1, 2 and 3."
            echo "================================================="
            echo ""
-           hardware_versions="1 2 3"
+           hardware_versions="0 1 2 3"
            ;;
     esac
 fi


### PR DESCRIPTION
Running v1.1.x branch on a Pi Zero W, I noticed that it was not identified as such.

rcS updated in line with current version of http://elinux.org/RPi_HardwareHistory#Board_Revision_History