### PR TITLE
Don't loop forever after failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ The format of the _installer-config.txt_ file and the current defaults:
                               # "1" to enable this functionality.
     enable_uart=0             # Set to "1" to enable the UART. Disabled by default.
     gpu_mem=                  # specify the amount of RAM in MB that should be reserved for the GPU
+    try_again=0               # Specify action on failure. 0 (default) powers off. To reboot and try again,
+                              # set to 1. When set to 1, there is no limit to the number of retries.
 
 The timeserver parameter is only used during installation for _rdate_ which is used as fallback when setting the time with `ntpdate` fails.  
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -73,7 +73,7 @@ fail()
         umount /boot
     fi
 
-    read -t 10 || reboot && exit
+    read -t 10 || poweroff && exit
     sh
 }
 

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -46,6 +46,7 @@ hwrng_support=1
 enable_watchdog=0
 enable_uart=0
 gpu_mem=
+try_again=0
 
 # these shouldn't really be changed unless auto-detection fails
 bootdev=/dev/mmcblk0
@@ -72,8 +73,13 @@ fail()
     if [ "$fail_boot_mounted" = true ] ; then
         umount /boot
     fi
-
-    read -t 10 || poweroff && exit
+    
+    if [ "$try_again" = 1 ] ; then
+        read -t 10 || reboot && exit
+    else
+        read -t 10 || poweroff && exit
+    fi
+    
     sh
 }
 


### PR DESCRIPTION
This rather simple change eliminates what, to me, is the most irritating problem for blind installs.

For those who run blind installs with no intention of ever connecting a keyboard or screen, the only way to tell if something has gone wrong is to wait....................................................

Can ping the pi, but not ssh, so it must be doing something. Yes it is. It's churning out error logs or, if it goes wrong before the time has been set, the same log over and over again...

 At least if it dies, it's hinting to take out the sd card and look at the log. 

For the eagle-eyed with a screen and keyboard, there's still the option to get into a shell.