### PR TITLE
Change update.sh and build.sh kernel versions to 4.9.0-6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 set -e
 
 # configuration
-KERNEL_VERSION_RPI1=4.9.0-4-rpi
-KERNEL_VERSION_RPI2=4.9.0-4-rpi2
+KERNEL_VERSION_RPI1=4.9.0-6-rpi
+KERNEL_VERSION_RPI2=4.9.0-6-rpi2
 
 INSTALL_MODULES=("kernel/fs/btrfs/btrfs.ko")
 INSTALL_MODULES+=("kernel/drivers/scsi/sg.ko")

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-KERNEL_VERSION_RPI1=4.9.0-4-rpi
-KERNEL_VERSION_RPI2=4.9.0-4-rpi2
+KERNEL_VERSION_RPI1=4.9.0-6-rpi
+KERNEL_VERSION_RPI2=4.9.0-6-rpi2
 
 RASPBIAN_ARCHIVE_KEY_DIRECTORY="https://archive.raspbian.org"
 RASPBIAN_ARCHIVE_KEY_FILE_NAME="raspbian.public.key"


### PR DESCRIPTION
Change update.sh and build.sh kernel versions to 4.9.0-6
due 4.9.0-4 exist no more in upstream.

Signed-off-by: Sami Olmari <sami@olmari.fi>