### PR TITLE
Fix almost all shellcheck issues.

### DIFF
--- a/buildroot.sh
+++ b/buildroot.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-IMG=raspbian-ua-netinst-`date +%Y%m%d`-git`git rev-parse --short @{0}`.img
+IMG=raspbian-ua-netinst-$(date +%Y%m%d)-git$(git rev-parse --short "@{0}").img
 
-rm -f $IMG
-rm -f $IMG.bz2
-rm -f $IMG.xz
+rm -f "$IMG"
+rm -f "$IMG".bz2
+rm -f "$IMG".xz
 
-dd if=/dev/zero of=$IMG bs=1M count=64
+dd if=/dev/zero of="$IMG" bs=1M count=64
 
-fdisk $IMG <<EOF
+fdisk "$IMG" <<EOF
 n
 p
 1
@@ -23,7 +23,7 @@ EOF
 
 if ! losetup --version &> /dev/null ; then
   losetup_lt_2_22=true
-elif [ $(echo $(losetup --version | rev|cut -f1 -d' '|rev|cut -d'.' -f-2)'<'2.22 | bc -l) -ne 0 ]; then
+elif [ "$(echo "$(losetup --version | rev|cut -f1 -d' '|rev|cut -d'.' -f-2)"'<'2.22 | bc -l)" -ne 0 ]; then
   losetup_lt_2_22=true
 else
   losetup_lt_2_22=false
@@ -31,28 +31,28 @@ fi
 
 if [ "$losetup_lt_2_22" = "true" ] ; then
 
-  kpartx -as $IMG
+  kpartx -as "$IMG"
   mkfs.vfat /dev/mapper/loop0p1
   mount /dev/mapper/loop0p1 /mnt
   cp -r bootfs/* /mnt/
   umount /mnt
-  kpartx -d $IMG || true
+  kpartx -d "$IMG" || true
 
 else
 
-  losetup --find --partscan $IMG
-  LOOP_DEV="$(losetup --associated $IMG | cut -f1 -d':')"
-  mkfs.vfat ${LOOP_DEV}p1
-  mount ${LOOP_DEV}p1 /mnt
+  losetup --find --partscan "$IMG"
+  LOOP_DEV="$(losetup --associated "$IMG" | cut -f1 -d':')"
+  mkfs.vfat "${LOOP_DEV}"p1
+  mount "${LOOP_DEV}"p1 /mnt
   cp -r bootfs/* /mnt/
   umount /mnt
-  losetup --detach ${LOOP_DEV}
+  losetup --detach "${LOOP_DEV}"
 
 fi
 
-if ! xz -9 --keep $IMG ; then
+if ! xz -9 --keep "$IMG" ; then
   # This happens e.g. on Raspberry Pi because xz runs out of memory.
   echo "WARNING: Could not create '$IMG.xz' variant." >&2
 fi
 
-cat $IMG | bzip2 -9 > $IMG.bz2
+bzip2 -k -9 "$IMG"

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm -rf bootfs rootfs firmware packages tmp installer*.cpio installer*.cpio.gz *.zip *.xz *.bz2 *.img
+rm -rf -- bootfs rootfs firmware packages tmp installer*.cpio installer*.cpio.gz *.zip *.xz *.bz2 *.img

--- a/update.sh
+++ b/update.sh
@@ -111,7 +111,7 @@ check_key() {
     echo -n "Checking key file '${KEY_FILE}'... "
 
     # check that there is only 1 public key in the key file
-    if [ "$(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons "${KEY_FILE}" | grep ^pub: | wc -l)" -ne 1 ] ; then
+    if [ "$(gpg --homedir gnupg --keyid-format long --with-fingerprint --with-colons "${KEY_FILE}" | grep -c ^pub:)" -ne 1 ] ; then
         echo "FAILED!"
         echo "There are zero or more than one keys in the ${KEY_FILE} key file!"
         return 1
@@ -171,15 +171,15 @@ setup_archive_keys() {
 }
 
 required() {
-    for i in ${packages[@]}; do
-        [[ $i = $1 ]] && return 0
+    for i in "${packages[@]}"; do
+        [[ $i = "$1" ]] && return 0
     done
     return 1
 }
 
 unset_required() {
-    for i in ${!packages[@]}; do
-        [[ ${packages[$i]} = $1 ]] && unset packages[$i] && return 0
+    for i in "${!packages[@]}"; do
+        [[ ${packages[$i]} = "$1" ]] && unset 'packages[$i]' && return 0
     done
     return 1
 }
@@ -313,7 +313,7 @@ download_packages() {
 
 # Setup
 rm -rf packages/
-mkdir packages/ && cd packages
+mkdir packages/ && cd packages || exit 1
 
 if ! setup_archive_keys ; then
     echo -e "ERROR\nSetting up the archives failed! Exiting."
@@ -335,7 +335,7 @@ search_for_packages raspbian "${mirror_raspbian}"
 
 if ! allfound ; then
     echo "ERROR: Unable to find all required packages in package list!"
-    echo "Missing packages: ${packages[@]}"
+    echo "Missing packages: " "${packages[@]}"
     cd ..
     exit 1
 fi


### PR DESCRIPTION
Debian Buster releases with bash 5.0 and things that worked fine with 4.4, now start giving 'weird' issues.
By fixing the issues that shellcheck (already) reported, the scripts started to work correctly consistently again.